### PR TITLE
Thread Tile Writing and Speed Up Pbf Parsing

### DIFF
--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -1,6 +1,7 @@
 #include "mjolnir/graphtilebuilder.h"
 
 #include <boost/filesystem/operations.hpp>
+#include <stdexcept>
 
 using namespace valhalla::baldr;
 
@@ -13,7 +14,7 @@ GraphTileBuilder::GraphTileBuilder():GraphTile(), edgeinfo_size_(0), textlist_si
 
 // Output the tile to file. Stores as binary data.
 
-bool GraphTileBuilder::StoreTileData(const std::string& basedirectory,
+void GraphTileBuilder::StoreTileData(const std::string& basedirectory,
                                      const GraphId& graphid) {
   // Get the name of the file
   boost::filesystem::path filename = Filename(basedirectory, graphid);
@@ -36,14 +37,14 @@ bool GraphTileBuilder::StoreTileData(const std::string& basedirectory,
         header_builder_.edgeinfo_offset() + edgeinfo_size_);
 
     // TODO - rm later
-    std::cout << ">>>>> header_builder_.nodecount_"
+    /*std::cout << ">>>>> header_builder_.nodecount_"
               << header_builder_.nodecount()
               << "  header_builder_.directededgecount_ = "
               << header_builder_.directededgecount()
               << "  header_builder_.edgeinfo_offset_ = "
               << header_builder_.edgeinfo_offset()
               << "  header_builder_.textlist_offset_ = "
-              << header_builder_.textlist_offset() << std::endl;
+              << header_builder_.textlist_offset() << std::endl;*/
 
     // Write the header.
     file.write(reinterpret_cast<const char*>(&header_builder_),
@@ -63,17 +64,16 @@ bool GraphTileBuilder::StoreTileData(const std::string& basedirectory,
     // Write the names
     SerializeTextListToOstream(file);
 
-    std::cout << "Write: " << filename << " nodes = " << nodes_builder_.size()
+    /*std::cout << "Write: " << filename << " nodes = " << nodes_builder_.size()
               << " directededges = " << directededges_builder_.size()
               << " edgeinfo size = " << edgeinfo_size_ << " textlist size = "
               << textlist_size_ << std::endl;
-
+*/
+    size_ = file.tellp();
     file.close();
-    return true;
   } else {
-    std::cout << "Failed to open file " << filename << std::endl;
+    throw std::runtime_error("Failed to open file " + filename.string());
   }
-  return false;
 }
 
 void GraphTileBuilder::AddNodeAndDirectedEdges(

--- a/src/mjolnir/pbfgraphbuilder/graphbuilder.cc
+++ b/src/mjolnir/pbfgraphbuilder/graphbuilder.cc
@@ -96,6 +96,8 @@ void GraphBuilder::node_callback(uint64_t osmid, double lng, double lat,
   if (osmid > maxosmid_)
     maxosmid_ = osmid;
 
+  node_count_++;
+
   // Check if it is in the list of nodes used by ways
   if (!osmnodeids_.IsUsed(osmid)) {
     return;

--- a/src/mjolnir/pbfgraphbuilder/graphbuilder.cc
+++ b/src/mjolnir/pbfgraphbuilder/graphbuilder.cc
@@ -683,7 +683,7 @@ void BuildTileRange(std::unordered_map<GraphId, std::vector<uint64_t> >::const_i
 }
 
 //TODO: make this an option
-constexpr size_t kThreadCount = 8;
+constexpr size_t kThreadCount = 4;
 
 }
 

--- a/src/mjolnir/pbfgraphbuilder/graphbuilder.cc
+++ b/src/mjolnir/pbfgraphbuilder/graphbuilder.cc
@@ -20,12 +20,6 @@
 using namespace valhalla::midgard;
 using namespace valhalla::baldr;
 
-namespace {
-
-  const size_t kAsyncBatchSize = 64;
-
-}
-
 namespace valhalla {
 namespace mjolnir {
 

--- a/src/mjolnir/pbfgraphbuilder/graphbuilder.h
+++ b/src/mjolnir/pbfgraphbuilder/graphbuilder.h
@@ -157,8 +157,6 @@ class GraphBuilder {
 
  protected:
 
-  bool preprocess_;
-
   uint64_t maxosmid_;
   uint32_t skippedhighway_;
   uint32_t relation_count_;

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -30,7 +30,7 @@ class GraphTileBuilder : public baldr::GraphTile {
    * @param  graphid  GraphID to store.
    * @param  basedirectory  Base data directory
    */
-  bool StoreTileData(const std::string& basedirectory,
+  void StoreTileData(const std::string& basedirectory,
                      const baldr::GraphId& graphid);
 
 


### PR DESCRIPTION
This pr adds threaded writing of tiles. Currently its hardcoded to spawn 4 threads. In practice this doesnt seem to do a good job of writing in parallel. Often a thread will finish writing all of its tiles before the next thread starts up. Hopefully I can figure out why and fix that.

I noticed that the bulk of the time spent makign tiles though is spent in parsing the pbf, rather running over the in memory data structure constructed from the pbf file. I added a bit of code to tell the ripped off code that we have to skip the bits we dont need and this significantly sped up the PA import. With the default optimization flags this made a huge difference something like 2m 30s down to 1m 50s. With the -O3 flag turned on the threaded branch is only 7% faster or something like that. I think what we really need to do is make parsing of the pbf threaded and write the parsers ourselves (there is a lot of copying around of data in there).