### PR TITLE
write compressed shape to tile

### DIFF
--- a/src/mjolnir/edgeinfobuilder.cc
+++ b/src/mjolnir/edgeinfobuilder.cc
@@ -2,102 +2,50 @@
 #include <ostream>
 #include <iostream>
 
+#include <valhalla/midgard/util.h>
+#include <valhalla/baldr/edgeinfo.h>
 #include "mjolnir/edgeinfobuilder.h"
 
 namespace valhalla {
 namespace mjolnir {
 
-// Constructor
-EdgeInfoBuilder::EdgeInfoBuilder() {
-  item_ = new PackedItem();
-}
-
-EdgeInfoBuilder::EdgeInfoBuilder(const EdgeInfoBuilder& other) {
-  item_ = new PackedItem(*(other.item_));
-  street_name_offset_list_ = other.street_name_offset_list_;
-  shape_ = other.shape_;
-  exit_signs_ = other.exit_signs_;
-}
-
-EdgeInfoBuilder& EdgeInfoBuilder::operator=(const EdgeInfoBuilder& rhs) {
-  if (&rhs != this) {
-    item_ = new PackedItem(*(rhs.item_));
-    street_name_offset_list_ = rhs.street_name_offset_list_;
-    shape_ = rhs.shape_;
-    exit_signs_ = rhs.exit_signs_;
-  }
-  return *this;
-}
-
-EdgeInfoBuilder::~EdgeInfoBuilder() {
-  if (item_) {
-    delete item_;
-    item_ = nullptr;
-  }
-}
-
 // Set the indexes to names used by this edge.
 void EdgeInfoBuilder::set_street_name_offset_list(
     const std::vector<uint32_t>& street_name_offset_list) {
   street_name_offset_list_ = street_name_offset_list;
-
-  // Set the name count
-  item_->fields.name_count = street_name_offset_list_.size();
 }
 
 // Set the shape of the edge. TODO - move?
 void EdgeInfoBuilder::set_shape(const std::vector<PointLL>& shape) {
   // Set the shape
-  shape_.assign(shape.begin(), shape.end());
-
-  // Set the shape count
-  item_->fields.shape_count = shape_.size();
-}
-
-const uint32_t EdgeInfoBuilder::GetStreetNameOffset(uint8_t index) const {
-  return street_name_offset_list_[index];
-}
-
-const PointLL EdgeInfoBuilder::GetShapePoint(uint16_t index) const {
-  return shape_[index];
+  encoded_shape_ = midgard::encode<std::vector<PointLL> >(shape);
 }
 
 std::size_t EdgeInfoBuilder::SizeOf() const {
   std::size_t size = 0;
-  size += sizeof(PackedItem);                                  // item_
-  size += (street_name_offset_list_.size() * sizeof(uint32_t));  // street_name_offset_list_
-  size += (shape_.size() * sizeof(PointLL));                   // shape_
-  size += (exit_signs_.size() * sizeof(ExitSign));             // exit_signs_
-
+  size += sizeof(baldr::EdgeInfo::PackedItem);
+  size += (street_name_offset_list_.size() * sizeof(uint32_t));
+  size += (encoded_shape_.size() * sizeof(std::string::value_type));
+  size += (exit_signs_.size() * sizeof(ExitSign));
   return size;
 }
 
-void EdgeInfoBuilder::SerializeToOstream(std::ostream& out) const {
-  // TODO - rm later
-  /*std::cout << "------------------------------------------------------"
-            << std::endl;
-  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
-  std::cout << "EdgeInfoBuilder::SizeOf=" << SizeOf() << std::endl;
-  std::cout << "item_=" << item_->value << std::endl;
-  std::cout << "name_count=" << street_name_offset_list_.size() << std::endl;
-  for (auto name_offset : street_name_offset_list_) {
-    std::cout << "   name_offset=" << name_offset << std::endl;
-  }
-  std::cout << "shape_count=" << shape_.size() << std::endl;
-  for (const auto& ll : shape_) {
-    std::cout << "   ll=" << ll.lat() << "," << ll.lng() << std::endl;
-  }
-  std::cout << "exit_sign_count=" << exit_signs_.size() << std::endl;
-  std::cout << "======================================================="
-            << std::endl;*/
+std::ostream& operator<<(std::ostream& os, const EdgeInfoBuilder& eib) {
+  // Make packeditem
+  baldr::EdgeInfo::PackedItem item;
+  item.fields.name_count = static_cast<uint32_t>(eib.street_name_offset_list_.size());
+  item.fields.encoded_shape_size = static_cast<uint32_t>(eib.encoded_shape_.size());
+  item.fields.exit_sign_count = static_cast<uint32_t>(eib.exit_signs_.size());
 
-  out.write(reinterpret_cast<const char*>(item_), sizeof(PackedItem));
-  out.write(reinterpret_cast<const char*>(&street_name_offset_list_[0]),
-            (street_name_offset_list_.size() * sizeof(uint32_t)));
-  out.write(reinterpret_cast<const char*>(&shape_[0]),
-            (shape_.size() * sizeof(PointLL)));
-  out.write(reinterpret_cast<const char*>(&exit_signs_[0]),
-            (exit_signs_.size() * sizeof(ExitSign)));
+  // Write out the bytes
+  os.write(reinterpret_cast<const char*>(&item), sizeof(baldr::EdgeInfo::PackedItem));
+  os.write(reinterpret_cast<const char*>(&eib.street_name_offset_list_[0]),
+            (eib.street_name_offset_list_.size() * sizeof(uint32_t)));
+  os << eib.encoded_shape_;
+  os.write(reinterpret_cast<const char*>(&eib.exit_signs_[0]),
+            (eib.exit_signs_.size() * sizeof(ExitSign)));
+
+  return os;
 }
 
 }

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -115,13 +115,13 @@ void GraphTileBuilder::SetTextListAndSize(
 
 void GraphTileBuilder::SerializeEdgeInfosToOstream(std::ostream& out) {
   for (const auto& edgeinfo : edgeinfos_builder_) {
-    edgeinfo.SerializeToOstream(out);
+    out << edgeinfo;
   }
 }
 
 void GraphTileBuilder::SerializeTextListToOstream(std::ostream& out) {
   for (const auto& text : textlist_builder_) {
-    out.write(text.c_str(), (text.length() + 1));
+    out << text << '\0';
   }
 }
 

--- a/test/edgeinfobuilder.cc
+++ b/test/edgeinfobuilder.cc
@@ -8,18 +8,21 @@
 #include <valhalla/baldr/edgeinfo.h>
 #include "mjolnir/edgeinfobuilder.h"
 
+#include <boost/shared_array.hpp>
+#include <memory>
+
 using namespace std;
 using namespace valhalla::baldr;
 using namespace valhalla::mjolnir;
 
 namespace {
 
-void TryWriteRead(const EdgeInfoBuilder& eibuilder) {
+boost::shared_array<char> ToFileAndBack(const EdgeInfoBuilder& eibuilder) {
   // write EdgeInfoBuilder to binary file
   std::ofstream out_file("EdgeInfoBuilder_TestWriteRead.gph",
                          std::ios::out | std::ios::binary | std::ios::ate);
   if (out_file.is_open()) {
-    eibuilder.SerializeToOstream(out_file);
+    out_file << eibuilder;
     out_file.close();
   } else {
     throw runtime_error("Failed to open file for writing");
@@ -27,52 +30,23 @@ void TryWriteRead(const EdgeInfoBuilder& eibuilder) {
 
   // read EdgeInfo from binary file
   streampos size;
-  char * memblock;
+  boost::shared_array<char> memblock;
 
   std::ifstream in_file("EdgeInfoBuilder_TestWriteRead.gph",
                         std::ios::in | std::ios::binary | std::ios::ate);
   if (in_file.is_open()) {
     size = in_file.tellg();
-    memblock = new char[size];
+    memblock.reset(new char[size]);
     in_file.seekg(0, ios::beg);
-    in_file.read(memblock, size);
+    in_file.read(memblock.get(), size);
     in_file.close();
   }
 
-  // validate the read in fields to the original EdgeInfoBuilder
-  EdgeInfo* ei = new EdgeInfo(memblock);
-  ei->ToOstream();
-
-  if (!(eibuilder.name_count() == ei->name_count()))
-    throw runtime_error("WriteRead:name_count test failed");
-  if (!(eibuilder.shape_count() == ei->shape_count()))
-    throw runtime_error("WriteRead:shape_count test failed");
-  if (!(eibuilder.exit_sign_count() == ei->exit_sign_count()))
-    throw runtime_error("WriteRead:exit_sign_count test failed");
-  for (uint32_t x = 0, n = ei->name_count(); x < n; ++x) {
-    std::cout << x << ":eibuilder.GetStreetNameOffset="
-              << eibuilder.GetStreetNameOffset(x) << std::endl;
-    std::cout << x << ":ei->GetStreetNameOffset=" << ei->GetStreetNameOffset(x)
-              << std::endl;
-    if (!(eibuilder.GetStreetNameOffset(x) == ei->GetStreetNameOffset(x)))
-      throw runtime_error("WriteRead:GetStreetNameOffset test failed");
-  }
-  for (uint32_t x = 0, n = ei->shape_count(); x < n; ++x) {
-    std::cout << x << ":eibuilder.GetShapePoint="
-              << eibuilder.GetShapePoint(x).lat() << ","
-              << eibuilder.GetShapePoint(x).lng() << std::endl;
-    std::cout << x << ":ei->GetShapePoint=" << ei->GetShapePoint(x).lat() << ","
-              << ei->GetShapePoint(x).lng() << std::endl;
-    if (!(eibuilder.GetShapePoint(x) == ei->GetShapePoint(x)))
-      throw runtime_error("WriteRead:GetStreetNameOffset test failed");
-  }
-  // TODO exit sign test
-
-  delete ei;
-  delete[] memblock;
+  return memblock;
 }
 
 void TestWriteRead() {
+  // Make a builder to write the info to disk
   EdgeInfoBuilder eibuilder;
   std::vector<uint32_t> street_name_offset_list;
   street_name_offset_list.push_back(963);
@@ -83,8 +57,35 @@ void TestWriteRead() {
   shape.push_back(PointLL(-76.3002, 40.0433));
   shape.push_back(PointLL(-76.3036, 40.043));
   eibuilder.set_shape(shape);
-  // TODO: exit
-  TryWriteRead(eibuilder);
+  // TODO: exit signs
+
+  // Make an edge info object from the memory
+  boost::shared_array<char> memblock = ToFileAndBack(eibuilder);
+  std::unique_ptr<EdgeInfo> ei(new EdgeInfo(memblock.get()));
+
+  //TODO: errors thrown should say what was found and what was expected
+
+  // Validate the read in fields to the original EdgeInfoBuilder
+  if (!(street_name_offset_list.size() == ei->name_count()))
+    throw runtime_error("WriteRead:name_count test failed");
+  if (!(shape.size() == ei->shape().size()))
+    throw runtime_error("WriteRead:shape_count test failed");
+  if (!(0 == ei->exit_sign_count()))
+    throw runtime_error("WriteRead:exit_sign_count test failed");
+
+  // Check the name indices
+  for (uint8_t i = 0; i < ei->name_count(); ++i) {
+    if (!(street_name_offset_list[i] == ei->GetStreetNameOffset(static_cast<uint8_t>(i))))
+      throw runtime_error("WriteRead:GetStreetNameOffset test failed");
+  }
+
+  // Check the shape points
+  for (size_t i = 0; i < ei->shape().size(); ++i) {
+    if (!shape[i].ApproximatelyEqual(ei->shape()[i]))
+      throw runtime_error("WriteRead:shape test failed");
+  }
+  // TODO exit sign test
+
 }
 
 }

--- a/valhalla/mjolnir/edgeinfobuilder.h
+++ b/valhalla/mjolnir/edgeinfobuilder.h
@@ -3,11 +3,11 @@
 
 #include <vector>
 #include <string>
+#include <iostream>
 
 #include <valhalla/midgard/pointll.h>
 #include <valhalla/midgard/util.h>
 #include <valhalla/baldr/graphid.h>
-#include <valhalla/baldr/edgeinfo.h>
 #include <valhalla/baldr/exitsign.h>
 
 using namespace valhalla::midgard;
@@ -19,29 +19,9 @@ namespace mjolnir {
 /**
  * Edge information not required in shortest path algorithm and is
  * common among the 2 directions.
- */
-class EdgeInfoBuilder : public baldr::EdgeInfo {
+  */
+class EdgeInfoBuilder {
  public:
-  /**
-   * Constructor
-   */
-  EdgeInfoBuilder();
-
-  /**
-   * Copy Constructor
-   */
-  EdgeInfoBuilder(const EdgeInfoBuilder& other);
-
-  /**
-   * Copy Assignment
-   */
-  EdgeInfoBuilder& operator=(const EdgeInfoBuilder& rhs);
-
-  /**
-   * Destrcutor
-   */
-  virtual ~EdgeInfoBuilder();
-
   /**
    * Set the indexes to names used by this edge
    * @param  nameindexes  a list of name indexes.
@@ -55,28 +35,21 @@ class EdgeInfoBuilder : public baldr::EdgeInfo {
    */
   void set_shape(const std::vector<PointLL>& shape);
 
-  // Returns the name index at the specified index.
-  const uint32_t GetStreetNameOffset(uint8_t index) const;
-
-  // Returns the shape point at the specified index.
-  // TODO: replace with vector once it works
-  const PointLL GetShapePoint(uint16_t index) const;
-
   // Returns the size in bytes of this object.
   std::size_t SizeOf() const;
 
-  void SerializeToOstream(std::ostream& out) const;
-
- private:
+ protected:
 
   // List of roadname indexes
   std::vector<uint32_t> street_name_offset_list_;
 
   // Lat,lng shape of the edge
-  std::vector<PointLL> shape_;
+  std::string encoded_shape_;
 
   // List of exit signs (type and index)
   std::vector<ExitSign> exit_signs_;
+
+  friend std::ostream& operator<<(std::ostream& os, const EdgeInfoBuilder& id);
 
 };
 

--- a/valhalla/mjolnir/graphbuilder.h
+++ b/valhalla/mjolnir/graphbuilder.h
@@ -104,14 +104,13 @@ struct Edge {
    * @param drivereverse Auto use in the reverse direction of the edge
    */
   Edge(const uint64_t sourcenode, const uint32_t wayindex,
-       const midgard::PointLL& ll, const uint32_t importance,
-       const bool driveforward, const bool drivereverse)
+       const midgard::PointLL& ll, const OSMWay& way)
       : sourcenode_(sourcenode),
         targetnode_(0),
         wayindex_(wayindex) {
-    attributes_.fields.importance = importance;
-    attributes_.fields.driveableforward = driveforward;
-    attributes_.fields.driveablereverse = drivereverse;
+    attributes_.fields.importance = static_cast<uint32_t>(way.road_class());
+    attributes_.fields.driveableforward = way.auto_forward();
+    attributes_.fields.driveablereverse = way.auto_backward();
     latlngs_.emplace_back(ll);
   }
 


### PR DESCRIPTION
this cuts the size of the tiles in half. enough said.

just kidding. ive also removed a bunch of unneeded code to hopefully simplfy the edgeinfobuilder object. added some more copy elision in the actual constructing of the tiles (this time for the edges). used ostream << operators to do writing where we can. changed the test for edgeinfobuilder (and edgeinfo) to use updated interface.

depends on: https://github.com/valhalla/baldr/pull/36