### PR TITLE
Create graph hierarchies

### DIFF
--- a/src/mjolnir/hierarchybuilder/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder/hierarchybuilder.cc
@@ -140,9 +140,12 @@ void HierarchyBuilder::FormTilesInNewLevel(
       const TileHierarchy::TileLevel& new_level) {
   // Iterate through tiled nodes in the new level
   uint32_t tileid = 0;
+  uint32_t nodeid = 0;
   uint32_t edgecount = 0;
   uint32_t edgeindex = 0;
+  uint32_t edge_info_offset;
   uint8_t level = new_level.level;
+  std::vector<std::string> names;
   std::string basedir = tile_hierarchy_.tile_dir();
   for (const auto& newtile : tilednodes_) {
     // Skip if no new nodes
@@ -155,41 +158,65 @@ void HierarchyBuilder::FormTilesInNewLevel(
     GraphTileBuilder tilebuilder(basedir, GraphId(tileid, level, 0));
 
     // Iterate through the NewNodes in the tile at the new level
+    nodeid = 0;
     edgeindex = 0;
-    std::vector<NodeInfoBuilder> nodes;
-    std::vector<DirectedEdgeBuilder> directededges;
+    GraphId nodea, nodeb;
     for (const auto& newnode : newtile) {
       // Get the node in the base level
       GraphTile* tile = graphreader_.GetGraphTile(newnode.basenode);
 
       // Copy node information
+      nodea.Set(tileid, level, nodeid);
       NodeInfoBuilder node;
       const NodeInfo* oldnodeinfo = tile->node(newnode.basenode.id());
       node.set_latlng(oldnodeinfo->latlng());
       node.set_edge_index(edgeindex);
       node.set_bestrc(oldnodeinfo->bestrc());
 
-      // Get remaining directed edges for this node
-      // TODO - add shortcut edges first
+      // Set edge count from this node to 0
       edgecount = 0;
 
-      // Iterate through directed edges of the base node
+      // TODO - add shortcut edges first
+      // If node is not contracted then there may be shortcuts.
+      if (!newnode.contract) {
+
+      }
+
+      // Iterate through directed edges of the base node to get remaining
+      // directed edges (based on classification/importance cutoff)
+      std::vector<DirectedEdgeBuilder> directededges;
       const DirectedEdge* directededge = tile->directededge(
-              oldnodeinfo->edge_index());
+                oldnodeinfo->edge_index());
       for (uint32_t i = 0, n = oldnodeinfo->edge_count(); i < n;
                       i++, directededge++) {
         // Store the directed edge if less than the road class cutoff
         if (directededge->importance() <= new_level.importance) {
           // Copy the directed edge information and update end node,
           // edge data offset, and opp_index
-          DirectedEdgeBuilder newedge;
-//          newedge = *directededge;
-//          newedge.set_endnode(newendnode);
-          newedge.set_opp_index(0);  // TODO
+          DirectedEdge oldedge = *directededge;
+          DirectedEdgeBuilder newedge =
+              static_cast<DirectedEdgeBuilder&>(oldedge);
 
-          // Need to create edge data...
-          newedge.set_edgedataoffset(0);   // TODO!!!
+          // Set the end node for this edge
+          nodeb = nodemap_[directededge->endnode().value()];
+          newedge.set_endnode(nodeb);
 
+          // TODO - how do we set the opposing index?
+          newedge.set_opp_index(0);
+
+          // Get edge info, shape, and names from the old tile and add
+          // to the new
+          tile->GetNames(directededge->edgedataoffset(), names);
+          const std::shared_ptr<EdgeInfo> edgeinfo =
+                tile->edgeinfo(directededge->edgedataoffset());
+          edge_info_offset = tilebuilder.AddEdgeInfo(0, nodea,
+                 nodeb, edgeinfo->shape(), names);
+          newedge.set_edgedataoffset(edge_info_offset);
+
+          // TODO - need to add superseded flag if this edge was included in
+          // a shortcut
+
+          // Add directed edge
           directededges.emplace_back(std::move(newedge));
           edgecount++;
         }
@@ -197,19 +224,31 @@ void HierarchyBuilder::FormTilesInNewLevel(
 
       // Add the downward transition edge
       DirectedEdgeBuilder downwardedge;
+      downwardedge.set_endnode(newnode.basenode);
+      downwardedge.set_trans_down(true);
       directededges.emplace_back(std::move(downwardedge));
       edgecount++;
 
       // Set the edge count for the new node
-      node.set_edge_count(edgecount);
-      nodes.emplace_back(std::move(node));
+      node.set_edge_count(edgecount);;
+
+      // Add node and directed edge information to the tile
+      tilebuilder.AddNodeAndDirectedEdges(node, directededges);
+
+      // Increment node Id
+      nodeid++;
     }
+
+    // Store the new tile
+    tilebuilder.StoreTileData(basedir, GraphId(tileid, level, 0));
 
     // Increment tileid
     tileid++;
   }
 }
 
+// Connect nodes in the base level tiles to the new nodes in the new
+// hierarchy level.
 void HierarchyBuilder::ConnectBaseLevelToNewLevel(
       const TileHierarchy::TileLevel& base_level,
       const TileHierarchy::TileLevel& new_level) {
@@ -286,7 +325,7 @@ std::cout << "Add " << connections.size() << " connections to " <<
   std::vector<NodeInfoBuilder> nodes;
   std::vector<DirectedEdgeBuilder> directededges;
   for (uint32_t id = 0; id < existinghdr->nodecount(); id++) {
-    NodeInfoBuilder& node = tilebuilder.node(id);
+    NodeInfoBuilder node = tilebuilder.node(id);
 
     // Add directed edges
     uint32_t idx = node.edge_index();

--- a/src/mjolnir/hierarchybuilder/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder/hierarchybuilder.cc
@@ -347,6 +347,7 @@ std::cout << "Add " << connections.size() << " connections to " <<
       // TODO - do we need to set all access to true?
       DirectedEdgeBuilder edgeconnection;
       edgeconnection.set_trans_up(true);
+      edgeconnection.set_endnode(connections[n].newnode);
       directededges.emplace_back(std::move(edgeconnection));
 
       // Increment n and get the next base node Id that connects

--- a/src/mjolnir/hierarchybuilder/hierarchybuilder.h
+++ b/src/mjolnir/hierarchybuilder/hierarchybuilder.h
@@ -108,6 +108,12 @@ class HierarchyBuilder {
                    const baldr::GraphId& basenode) const;
 
   /**
+   * Form tiles in the new level
+   */
+  void FormTilesInNewLevel(const baldr::TileHierarchy::TileLevel& base_level,
+                           const baldr::TileHierarchy::TileLevel& new_level);
+
+  /**
    * Connect nodes in the base level to new nodes at the new level. This
    * inserts directed edges from the base node to the new node.
    */


### PR DESCRIPTION
Move the edgeinfo and text logic into GraphTileBuilder so it can be reused between GraphBuilder and HierarchyBuilder. Currently HierarchyBuilder is a separate process from pbfgraphbuilder. It runs pretty fast, but we may want to combine it with pbfgraphbuilder and perhaps add some concurrency to it later.
Creating tiles at each new hierarchy based on the prior hierarchy. Adding upward and downward transition edges.
Still need to add shortcut edges and test within PathAlgorithm, but making progress.

@kevinkreiser @gknisely @dgearhart 