### PR TITLE
HierarchyBuilder

### DIFF
--- a/valhalla/mjolnir/hierarchybuilder.h
+++ b/valhalla/mjolnir/hierarchybuilder.h
@@ -155,13 +155,13 @@ class HierarchyBuilder {
   /**
    * Adds shortcut edges from the node.
    */
-  uint32_t AddShortcutEdges(const NewNode& newnode,
-                            const baldr::GraphId& nodea,
-                            const baldr::NodeInfo* oldnodeinfo,
-                            baldr::GraphTile* tile,
-                            const baldr::RoadClass rcc,
-                            GraphTileBuilder& tilebuilder,
-                            std::vector<DirectedEdgeBuilder>& directededges);
+  void AddShortcutEdges(const NewNode& newnode,
+                        const baldr::GraphId& nodea,
+                        const baldr::NodeInfo* oldnodeinfo,
+                        baldr::GraphTile* tile,
+                        const baldr::RoadClass rcc,
+                        GraphTileBuilder& tilebuilder,
+                        std::vector<DirectedEdgeBuilder>& directededges);
 
   /**
    * Connect edges on the shortcut. Appends shape.


### PR DESCRIPTION
Updates to shortcut edges to create them in cases where the start is at a contracted node (but the edge is not part of the contracted set of edges).

Now there are very few shortcut edges that do not have opposing shortcut edges. 