### PR TITLE
Set use for links (either to kRamp or kTurnChannel)

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -27,9 +27,6 @@
 using namespace valhalla::midgard;
 using namespace valhalla::baldr;
 
-uint32_t rampcount = 0;
-uint32_t turnchannelcount = 0;
-
 namespace valhalla {
 namespace mjolnir {
 
@@ -776,16 +773,11 @@ void BuildTileSet(std::unordered_map<GraphId, std::vector<uint64_t> >::const_ite
           directededge.set_link(w.link());
           if (directededge.link()) {
             if (directededge.use() != Use::kNone) {
-              std::cout << "Edge is a link but has use = " <<
-                    static_cast<int>(directededge.use()) << std::endl;
+              LOG_WARN("Edge is a link but has use = " +
+                       std::to_string(static_cast<int>(directededge.use())));
             }
             directededge.set_use(GetLinkUse(w.road_class(), length,
                      edge.sourcenode_, edge.targetnode_, nodes));
-
-            if (directededge.use() == Use::kRamp)
-              rampcount++;
-            else if (directededge.use() == Use::kTurnChannel)
-              turnchannelcount++;
           }
 
           // Check if more important
@@ -957,10 +949,6 @@ void GraphBuilder::BuildLocalTiles(const uint8_t level) const {
       //TODO: throw further up the chain?
     }
   }
-
-  std::cout << "Ramp count = " << rampcount << " Turn Channel count = " <<
-            turnchannelcount << std::endl;
-
 
   /*// Wait for results to come back from the threads, logging what happened and removing the result
   auto process_result = [] (std::unordered_map<GraphId, std::future<size_t> >& results) {

--- a/src/mjolnir/graphoptimizer.cc
+++ b/src/mjolnir/graphoptimizer.cc
@@ -56,13 +56,7 @@ void GraphOptimizer::Optimize() {
                                   nodeinfo.edge_index() + j);
 
           // Set the opposing edge index
-          // NOTE: shortcut edges do not always have opposing shortcuts
-          // may need to fix this!
-          if (directededge.shortcut()) {
-            directededge.set_opp_index(31);
-          } else {
-            directededge.set_opp_index(GetOpposingEdgeIndex(node, directededge));
-          }
+          directededge.set_opp_index(GetOpposingEdgeIndex(node, directededge));
           directededges.emplace_back(std::move(directededge));
         }
 
@@ -93,7 +87,7 @@ uint32_t GraphOptimizer::GetOpposingEdgeIndex(const GraphId& node,
               nodeinfo->edge_index());
   for (uint32_t i = 0; i < n; i++, directededge++) {
     if (directededge->endnode() == node &&
-        fabs(directededge->length() - edge.length()) < 0.0001f) {
+        directededge->length() == edge.length()) {
       return i;
     }
   }
@@ -107,7 +101,7 @@ uint32_t GraphOptimizer::GetOpposingEdgeIndex(const GraphId& node,
   directededge =  tile->directededge(nodeinfo->edge_index());
   for (uint32_t i = 0; i < n; i++, directededge++) {
     std::cout << "    Length = " << directededge->length() << " Endnode: " <<
-        directededge->endnode() << std::endl;
+        directededge->endnode() << " Shortcut: " << directededge->shortcut() << std::endl;
   }
   return 0;
 }

--- a/src/mjolnir/osmnode.cc
+++ b/src/mjolnir/osmnode.cc
@@ -42,7 +42,10 @@ const baldr::GraphId& OSMNode::graphid() const {
 }
 
 // Add an edge to the list of outbound edges
-void OSMNode::AddEdge(const uint32_t edgeindex) {
+void OSMNode::AddEdge(const uint32_t edgeindex, const bool link) {
+  if (!link) {
+    attributes_.fields.non_link_edge = true;
+  }
   edges_.emplace_back(edgeindex);
 }
 
@@ -109,6 +112,12 @@ void OSMNode::set_modes_mask(const uint32_t modes_mask) {
 // Get the modes mask.
 bool OSMNode::modes_mask() const {
   return attributes_.fields.modes_mask;
+}
+
+// Get the non-link edge flag. True if any connected edge is not a
+// highway=*_link.
+bool OSMNode::non_link_edge() const {
+  return attributes_.fields.non_link_edge;
 }
 
 }

--- a/valhalla/mjolnir/osmnode.h
+++ b/valhalla/mjolnir/osmnode.h
@@ -55,8 +55,11 @@ class OSMNode {
 
   /**
    * Add an edge.
+   * @param  edgeindex  Index in the list of edges.
+   * @param  link       Flag indicating whether this edge is a link
+   *                    (highway=*_link)
    */
-  void AddEdge(const uint32_t edgeindex);
+  void AddEdge(const uint32_t edgeindex, const bool link);
 
   /**
    * Get the number of edges beginning or ending at the node.
@@ -127,6 +130,12 @@ class OSMNode {
    */
   bool modes_mask() const;
 
+  /**
+   * Get the non-link edge flag. True if any connected edge is not a
+   * highway=*_link.
+   */
+  bool non_link_edge() const;
+
  private:
   // Lat,lng of the node
   midgard::PointLL latlng_;
@@ -140,12 +149,13 @@ class OSMNode {
   // Node attributes
   union NodeAttributes {
     struct Fields {
-      uint16_t gate       : 1;
-      uint16_t bollard    : 1;
-      uint16_t exit_to    : 1;
-      uint16_t ref        : 1;
-      uint16_t modes_mask : 8;
-      uint16_t spare      : 4;
+      uint16_t gate          : 1;
+      uint16_t bollard       : 1;
+      uint16_t exit_to       : 1;
+      uint16_t ref           : 1;
+      uint16_t modes_mask    : 8;
+      uint16_t non_link_edge : 1;
+      uint16_t spare         : 3;
     } fields;
     uint16_t v;
   };


### PR DESCRIPTION
Turn channels are short, never motorway_link or trunk_link, have no exit information (TODO), and each end node connects to a non-link (e.g. neither end node connects only to links - indicating a split or fork).