### PR TITLE
Shape fixes for HierarchyBuilder

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -720,6 +720,7 @@ void BuildTileSet(std::unordered_map<GraphId, std::vector<uint64_t> >::const_ite
   size_t written = 0;
 
   // For each tile in the task
+  bool added = false;
   for(; tile_start != tile_end; ++tile_start) {
     try {
      // What actually writes the tile
@@ -856,7 +857,7 @@ void BuildTileSet(std::unordered_map<GraphId, std::vector<uint64_t> >::const_ite
 
           // Add edge info to the tile and set the offset in the directed edge
           uint32_t edge_info_offset = graphtile.AddEdgeInfo(edgeindex,
-               nodea, nodeb, edge.latlngs_, w.GetNames());
+               nodea, nodeb, edge.latlngs_, w.GetNames(), added);
           directededge.set_edgedataoffset(edge_info_offset);
         }
 

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -133,7 +133,8 @@ void GraphTileBuilder::AddNodeAndDirectedEdges(
 uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
              const GraphId& nodea, const baldr::GraphId& nodeb,
              const std::vector<PointLL>& lls,
-             const std::vector<std::string>& names) {
+             const std::vector<std::string>& names,
+             bool& added) {
   // If we haven't yet added edge info for this edge tuple
   auto edge_tuple_item = EdgeTuple(edgeindex, nodea, nodeb);
   auto existing_edge_offset_item = edge_offset_map.find(edge_tuple_item);
@@ -187,10 +188,12 @@ uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
     edge_info_offset_ += edgeinfo.SizeOf();
 
     // Return the offset to this edge info
+    added = true;
     return current_edge_offset;
   }
   else {
     // Already have this edge - return the offset
+    added = false;
     return existing_edge_offset_item->second;
   }
 }

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -512,20 +512,13 @@ uint32_t HierarchyBuilder::ConnectEdges(const GraphId& basenode,
   GraphTile* tile = graphreader_.GetGraphTile(basenode);
   const DirectedEdge* directededge = tile->directededge(edgeid);
 
-  // Get the shape for this edge
-  std::unique_ptr<const EdgeInfo> edgeinfo = tile->edgeinfo(
-      directededge->edgedataoffset());
-  std::vector<PointLL> edgeshape = edgeinfo->shape();
-
-  // Append the shape
-  if (edgeshape.front().ApproximatelyEqual(shape.back())) {
+  // Get the shape for this edge and append to the shortcut's shape
+  std::vector<PointLL> edgeshape = tile->edgeinfo(
+          directededge->edgedataoffset())->shape();
+  if (directededge->forward()) {
     shape.insert(shape.end(), edgeshape.begin() + 1, edgeshape.end());
-  } else if (edgeshape.back().ApproximatelyEqual(shape.back())) {
-    shape.insert(shape.end(), edgeshape.rbegin() + 1, edgeshape.rend());
   } else {
-    LOG_ERROR((boost::format("Connect edges mismatch: Shape end %1%,%2% Edge Begin %3%,%4% Edge End %5%,%6%")
-      % shape.back().lat() % shape.back().lng() % edgeshape.front().lat() % edgeshape.front().lng()
-      % edgeshape.back().lat() % edgeshape.back().lng()).str());
+    shape.insert(shape.end(), edgeshape.rbegin() + 1, edgeshape.rend());
   }
 
   // Update the end node and return the length

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -37,11 +37,12 @@ void TestDuplicateEdgeInfo() {
 
   test_graph_tile_builder test;
   //add edge info for node 0 to node 1
-  test.AddEdgeInfo(0, GraphId(0,2,0), GraphId(0,2,1), {{0, 0}, {1, 1}}, {"einzelweg"});
+  bool added = false;
+  test.AddEdgeInfo(0, GraphId(0,2,0), GraphId(0,2,1), {{0, 0}, {1, 1}}, {"einzelweg"}, added);
   if(test.edge_offset_map.size() != 1)
     throw std::runtime_error("There should be exactly one of these in here");
   //add edge info for node 1 to node 0
-  test.AddEdgeInfo(0, GraphId(0,2,1), GraphId(0,2,0), {{1, 1}, {0, 0}}, {"einzelweg"});
+  test.AddEdgeInfo(0, GraphId(0,2,1), GraphId(0,2,0), {{1, 1}, {0, 0}}, {"einzelweg"}, added);
   if(test.edge_offset_map.size() != 1)
     throw std::runtime_error("There should still be exactly one of these in here");
 }

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -80,7 +80,8 @@ class GraphTileBuilder : public baldr::GraphTile {
   uint32_t AddEdgeInfo(const uint32_t edgeindex, const baldr::GraphId& nodea,
                        const baldr::GraphId& nodeb,
                        const std::vector<PointLL>& lls,
-                       const std::vector<std::string>& names);
+                       const std::vector<std::string>& names,
+                       bool& added);
 
   /**
    * Gets a builder for a node from an existing tile.


### PR DESCRIPTION
The first edge info added is always forward direction. Needed to reverse the initial shape if the first directed edge was reverse.