### PR TITLE
Update ReclassifyLinks

### DIFF
--- a/valhalla/mjolnir/graphbuilder.h
+++ b/valhalla/mjolnir/graphbuilder.h
@@ -212,11 +212,11 @@ class GraphBuilder {
   void ReclassifyLinks();
 
   /**
-   * Get the road classifications for any non-link edges. Adds to
-   * the specified set.
+   * Get the best classification for any non-link edges from a node.
+   * @param  node  Node - gets outbound edges from this node.
+   * @return  Returns the best (most important) classification
    */
-  void GetNonLinkRoadClasses(const OSMNode& node,
-                             std::set<uint32_t>& nonlinkclasses) const;
+  uint32_t GetBestNonLinkClass(const OSMNode& node) const;
 
   /**
    * Build tiles representing the local graph


### PR DESCRIPTION
Trick was to select the best non-link classification at the start node, expand edges until all other nodes with non-link edges are encountered and track the best non-link classification encountered at the end nodes. Then all link edges traversed get assigned the maximum of the best class at the start and the best class at the end (the max means a lesser classification/importance). Had to be careful for cases where the link edges don't actually connect - log these cases.
Also  fix setting not_thru edges - was not adding the proper node to the exand set. 