### PR TITLE
make sublogging configs so they can be configured within the same file

### DIFF
--- a/conf/mjolnir/pbf2graph.json
+++ b/conf/mjolnir/pbf2graph.json
@@ -17,7 +17,9 @@
     "way_function": "ways_proc"
   },
   "logging": {
-    "type": "std_out",
-    "color": true
+    "mjolnir": {
+      "type": "std_out",
+      "color": true
+    }
   }
 }

--- a/src/mjolnir/pbfgraphbuilder.cc
+++ b/src/mjolnir/pbfgraphbuilder.cc
@@ -15,6 +15,7 @@ using namespace valhalla::mjolnir;
 #include <boost/filesystem/operations.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/optional.hpp>
 
 #include <valhalla/midgard/point2.h>
 #include <valhalla/midgard/aabb2.h>
@@ -107,9 +108,11 @@ int main(int argc, char** argv) {
   boost::property_tree::read_json(config_file_path.c_str(), pt);
 
   //configure logging
-  boost::property_tree::ptree logging_subtree = pt.get_child("logging");
-  auto logging_config = valhalla::midgard::ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string> >(logging_subtree);
-  valhalla::midgard::logging::Configure(logging_config);
+  boost::optional<boost::property_tree::ptree&> logging_subtree = pt.get_child_optional("logging.mjolnir");
+  if(logging_subtree) {
+    auto logging_config = valhalla::midgard::ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string> >(logging_subtree.get());
+    valhalla::midgard::logging::Configure(logging_config);
+  }
 
   //we only support protobuf at present
   std::string input_type = pt.get<std::string>("input.type");


### PR DESCRIPTION
this is useful for chef so that we dont ahve to have a seprate config file for every single process we want to run. it also makes it so that pbfgraphbuilder wont bomb if you dont specify logging for it, it will just default to stdout