### PR TITLE
Add plumbing for adding simple turn restrictions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,6 +63,7 @@ nobase_include_HEADERS = \
 	valhalla/mjolnir/osmway.h \
 	valhalla/mjolnir/pbfparser.h \
 	valhalla/mjolnir/signbuilder.h \
+	valhalla/mjolnir/turnrestrictionbuilder.h \
         valhalla/mjolnir/util.h
 libvalhalla_mjolnir_la_SOURCES = \
 	src/mjolnir/dataquality.cc \
@@ -83,6 +84,7 @@ libvalhalla_mjolnir_la_SOURCES = \
         src/mjolnir/osmway.cc \
         src/mjolnir/pbfparser.cc \
 	src/mjolnir/signbuilder.cc \
+	src/mjolnir/turnrestrictionbuilder.cc \
         src/mjolnir/util.cc
 libvalhalla_mjolnir_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 libvalhalla_mjolnir_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIB@ @PROTOC_LIBS@ 

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -62,7 +62,14 @@ void DirectedEdgeBuilder::set_edgeinfo_offset(const uint32_t offset) {
   dataoffsets_.edgeinfo_offset = offset;
 }
 
-//Sets the exit flag.
+// Set the simple turn restriction flag. This indicates the directed edge
+// forms the start of a simple turn restriction. These are turn restrictions
+// from one edge to another that apply to all vehicles, at all times.
+void DirectedEdgeBuilder::set_simple_tr(const bool tr) {
+  dataoffsets_.simple_tr = tr;
+}
+
+// Sets the exit flag.
 void DirectedEdgeBuilder::set_exitsign(const bool exit) {
   dataoffsets_.exitsign = exit;
 }

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -68,6 +68,10 @@ void GraphTileBuilder::StoreTileData(const baldr::TileHierarchy& hierarchy,
     file.write(reinterpret_cast<const char*>(&signs_builder_[0]),
                signs_builder_.size() * sizeof(SignBuilder));
 
+    // Write the turn restrictions
+    file.write(reinterpret_cast<const char*>(&turnrestriction_builder_[0]),
+               turnrestriction_builder_.size() * sizeof(TurnRestrictionBuilder));
+
     // Write the edge data
     SerializeEdgeInfosToOstream(file);
 
@@ -117,6 +121,10 @@ void GraphTileBuilder::Update(const baldr::TileHierarchy& hierarchy,
     file.write(reinterpret_cast<const char*>(&signs_[0]),
                hdr.signcount() * sizeof(Sign));
 
+    // Write the existing turn restrictions
+    file.write(reinterpret_cast<const char*>(&turnrestrictions_[0]),
+               hdr.turnrestriction_count() * sizeof(TurnRestriction));
+
     // Write the existing edgeinfo, and textlist
     file.write(edgeinfo_, edgeinfo_size_);
     file.write(textlist_, textlist_size_);
@@ -133,7 +141,8 @@ void GraphTileBuilder::Update(const baldr::TileHierarchy& hierarchy,
                 const GraphTileHeaderBuilder& hdr,
                 const std::vector<NodeInfoBuilder>& nodes,
                 const std::vector<DirectedEdgeBuilder>& directededges,
-                const std::vector<SignBuilder>& signs) {
+                const std::vector<SignBuilder>& signs,
+                const std::vector<TurnRestrictionBuilder>& trs) {
   // Get the name of the file
   boost::filesystem::path filename = hierarchy.tile_dir() + '/' +
             GraphTile::FileSuffix(hdr.graphid(), hierarchy);
@@ -161,6 +170,10 @@ void GraphTileBuilder::Update(const baldr::TileHierarchy& hierarchy,
     // Write the updated signs
     file.write(reinterpret_cast<const char*>(&signs[0]),
                signs.size() * sizeof(SignBuilder));
+
+    // Write the updated signs
+    file.write(reinterpret_cast<const char*>(&trs[0]),
+               trs.size() * sizeof(TurnRestrictionBuilder));
 
     // Write the existing edgeinfo and textlist
     file.write(edgeinfo_, edgeinfo_size_);

--- a/src/mjolnir/graphtileheaderbuilder.cc
+++ b/src/mjolnir/graphtileheaderbuilder.cc
@@ -47,6 +47,11 @@ void GraphTileHeaderBuilder::set_signcount(const uint32_t count) {
   signcount_ = count;
 }
 
+// Sets the number of simple turn restrictions within this tile.
+void GraphTileHeaderBuilder::set_turnrestriction_count(const uint32_t count) {
+  turnrestriction_count_ = count;
+}
+
 // Sets the offset to the edge info.
 void GraphTileHeaderBuilder::set_edgeinfo_offset(const uint32_t offset) {
   edgeinfo_offset_ = offset;

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -212,6 +212,8 @@ bool HierarchyBuilder::EdgesMatch(const GraphTile* tile, const DirectedEdge* edg
     return false;
   }
 
+  // TODO - turn restrictions...
+
   // Importance (class), link, use, and attributes must also match.
   // NOTE: might want "better" bridge attribution. Seems most overpasses
   // get marked as a bridge and lead to less shortcuts - so we don't consider
@@ -647,6 +649,8 @@ void HierarchyBuilder::AddConnectionsToBaseTile(
   uint32_t nextsignidx = (tilebuilder.header()->signcount() > 0) ?
       tilebuilder.sign(0).edgeindex() : existinghdr.directededgecount() + 1;
 
+  // TODO - update turn restrictions
+
   // Get the nodes. For any that have a connection add to the edge count
   // and increase the edge_index by (n = number of directed edges added so far)
   uint32_t n = 0;
@@ -656,6 +660,7 @@ void HierarchyBuilder::AddConnectionsToBaseTile(
   std::vector<NodeInfoBuilder> nodes;
   std::vector<DirectedEdgeBuilder> directededges;
   std::vector<SignBuilder> signs;
+  std::vector<TurnRestrictionBuilder> turnrestrictions;
   for (uint32_t id = 0; id < existinghdr.nodecount(); id++) {
     NodeInfoBuilder node = tilebuilder.node(id);
 
@@ -723,7 +728,8 @@ void HierarchyBuilder::AddConnectionsToBaseTile(
   }
 
   // Write the new file
-  tilebuilder.Update(tile_hierarchy_, hdrbuilder, nodes, directededges, signs);
+  tilebuilder.Update(tile_hierarchy_, hdrbuilder, nodes, directededges, signs,
+                     turnrestrictions);
 
   LOG_INFO((boost::format("HierarchyBuilder updated tile %1%: %2% bytes") %
       basetile % tilebuilder.size()).str());

--- a/src/mjolnir/osmrestriction.cc
+++ b/src/mjolnir/osmrestriction.cc
@@ -1,13 +1,14 @@
 #include "mjolnir/osmrestriction.h"
 
+using namespace valhalla::baldr;
+
 namespace valhalla {
 namespace mjolnir {
 
 OSMRestriction::OSMRestriction()
-    : attributes_{},
-      from_(0),
-      via_(0),
-      to_(0) {
+    : via_{},
+      to_(0),
+      attributes_{} {
 }
 
 OSMRestriction::~OSMRestriction() {
@@ -83,23 +84,24 @@ uint32_t OSMRestriction::minute_off() const {
   return attributes_.minute_off_;
 }
 
-// Set the from way id
-void OSMRestriction::set_from(uint64_t from) {
-  from_ = from;
-}
-
-// Get the from way id
-uint64_t OSMRestriction::from() const {
-  return from_;
+// Set the via id
+void OSMRestriction::set_via(uint64_t via) {
+  via_.osmid = via;
 }
 
 // Set the via id
-void OSMRestriction::set_via(uint64_t via) {
-  via_ = via;
+void OSMRestriction::set_via(const GraphId& id) {
+  via_.id = id;
 }
-// Get the via id
+
+// Get the via OSM node id
 uint64_t OSMRestriction::via() const {
-  return via_;
+  return via_.osmid;
+}
+
+// Get the via node's GraphId
+const GraphId& OSMRestriction::via_graphid() const {
+  return via_.id;
 }
 
 // Set the to way id

--- a/src/mjolnir/osmway.cc
+++ b/src/mjolnir/osmway.cc
@@ -3,6 +3,8 @@
 
 #include <valhalla/midgard/logging.h>
 
+using namespace valhalla::baldr;
+
 namespace valhalla {
 namespace mjolnir {
 

--- a/src/mjolnir/signbuilder.cc
+++ b/src/mjolnir/signbuilder.cc
@@ -1,4 +1,4 @@
-#include "../../valhalla/mjolnir/signbuilder.h"
+#include "mjolnir/signbuilder.h"
 
 using namespace valhalla::baldr;
 

--- a/src/mjolnir/turnrestrictionbuilder.cc
+++ b/src/mjolnir/turnrestrictionbuilder.cc
@@ -1,0 +1,23 @@
+#include "mjolnir/turnrestrictionbuilder.h"
+
+using namespace valhalla::baldr;
+
+namespace valhalla {
+namespace mjolnir {
+
+// Constructor with arguments
+TurnRestrictionBuilder::TurnRestrictionBuilder(const uint32_t idx,
+                                 const RestrictionType type,
+                                 const uint32_t mask) {
+  data_.edgeindex = idx;
+  data_.type = static_cast<uint32_t>(type);
+  restriction_mask_ = mask;
+}
+
+// Set the directed edge index.
+void TurnRestrictionBuilder::set_edgeindex(const uint32_t idx) {
+  data_.edgeindex = idx;
+}
+
+}
+}

--- a/src/mjolnir/uniquenames.cc
+++ b/src/mjolnir/uniquenames.cc
@@ -5,8 +5,6 @@
 namespace valhalla {
 namespace mjolnir {
 
-using NameIndexType = std::unordered_map<std::string, uint32_t>;
-
 // Constructor
 UniqueNames::UniqueNames() {
   // Insert dummy so index 0 is never used
@@ -24,7 +22,7 @@ uint32_t UniqueNames::index(const std::string& name) {
   }
   else {
      // Not in the map, add index and update
-     it = names_.insert(it, NameIndexType::value_type(name, 0));
+     it = names_.insert(it, NamesMap::value_type(name, 0));
      indexes_.push_back(it);
      index = indexes_.size() - 1;
      it->second = index;

--- a/valhalla/mjolnir/directededgebuilder.h
+++ b/valhalla/mjolnir/directededgebuilder.h
@@ -140,6 +140,15 @@ class DirectedEdgeBuilder : public baldr::DirectedEdge {
   void set_toll(const bool toll);
 
   /**
+   * Set the simple turn restriction flag. This indicates the directed edge
+   * forms the start of a simple turn restriction. These are turn restrictions
+   * from one edge to another that apply to all vehicles, at all times.
+   * @param  tr  Flag indicating whether this directed edge starts a simple turn
+   *             restriction.
+   */
+  void set_simple_tr(const bool tr);
+
+  /**
    * Sets the exit sign flag.
    * @param  exit  True if this directed edge has exit signs, false if not.
    */

--- a/valhalla/mjolnir/graphbuilder.h
+++ b/valhalla/mjolnir/graphbuilder.h
@@ -275,6 +275,12 @@ class GraphBuilder {
    */
   void CreateNodeMaps(const OSMData& osmdata);
 
+  /**
+   * Update restrictions. Replace OSM node Ids with GraphIds.
+   * @param  osmdata  Includes the restrictions
+   */
+  void UpdateRestrictions(OSMData& osmdata);
+
   // List of the tile levels to be created
   uint32_t level_;
   TileHierarchy tile_hierarchy_;

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -20,6 +20,7 @@
 #include <valhalla/mjolnir/graphtileheaderbuilder.h>
 #include <valhalla/mjolnir/nodeinfobuilder.h>
 #include <valhalla/mjolnir/directededgebuilder.h>
+#include <valhalla/mjolnir/turnrestrictionbuilder.h>
 #include <valhalla/mjolnir/edgeinfobuilder.h>
 #include <valhalla/baldr/tilehierarchy.h>
 #include "signbuilder.h"
@@ -71,19 +72,22 @@ class GraphTileBuilder : public baldr::GraphTile {
                const std::vector<DirectedEdgeBuilder>& directededges);
 
   /**
-   * Update a graph tile with new header, nodes, directed edges, and exits.
+   * Update a graph tile with new header, nodes, directed edges, signs,
+   * and turn restrictions.
    * This is used to add directed edges connecting two hierarchy levels.
    * @param  hierarchy      How the tiles are setup on disk
    * @param  hdr            Update header
    * @param  nodes          Update list of nodes
    * @param  directededges  Updated list of edges.
    * @param  signs          Updated list of signs.
+   * @param  trs            Updated list of turn restrictions.
    */
   void Update(const baldr::TileHierarchy& hierarchy,
               const GraphTileHeaderBuilder& hdr,
               const std::vector<NodeInfoBuilder>& nodes,
               const std::vector<DirectedEdgeBuilder>& directededges,
-              const std::vector<SignBuilder>& signs);
+              const std::vector<SignBuilder>& signs,
+              const std::vector<TurnRestrictionBuilder>& trs);
 
   /**
    * Add a node and its outbound edges.
@@ -99,6 +103,14 @@ class GraphTileBuilder : public baldr::GraphTile {
    */
   void AddSigns(const uint32_t idx,
                 const std::vector<baldr::SignInfo>& signs);
+
+  /**
+   * Add simple turn restrictions.
+   * @param  idx  Directed edge index.
+   * @param  trs  Turn restrictions
+   */
+  void AddTurnRestrictions(const uint32_t idx,
+                const std::vector<baldr::TurnRestriction>& trs);
 
   /**
    * Add edge info to the tile.
@@ -171,6 +183,10 @@ class GraphTileBuilder : public baldr::GraphTile {
   // List of signs. This is a fixed size structure so it can be
   // indexed directly.
   std::vector<SignBuilder> signs_builder_;
+
+  // List of turn restrictions. This is a fixed size structure so it can be
+  // indexed directly.
+  std::vector<TurnRestrictionBuilder> turnrestriction_builder_;
 
   // Edge info offset and map
   size_t edge_info_offset_ = 0;

--- a/valhalla/mjolnir/graphtileheaderbuilder.h
+++ b/valhalla/mjolnir/graphtileheaderbuilder.h
@@ -59,6 +59,12 @@ class GraphTileHeaderBuilder : public baldr::GraphTileHeader {
   void set_signcount(const uint32_t count);
 
   /**
+   * Sets the number of simple turn restrictions within this tile.
+   * @param count Number of simple turn restrictions within the tile.
+   */
+  void set_turnrestriction_count(const uint32_t count);
+
+  /**
    * Sets the offset to the edge info.
    * @param offset Offset in bytes to the start of the edge information.
    */

--- a/valhalla/mjolnir/osmdata.h
+++ b/valhalla/mjolnir/osmdata.h
@@ -1,7 +1,6 @@
 #ifndef VALHALLA_MJOLNIR_OSMDATA_H
 #define VALHALLA_MJOLNIR_OSMDATA_H
 
-//#include <stxxl.h>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -11,13 +10,14 @@
 #include <valhalla/mjolnir/osmrestriction.h>
 #include <valhalla/mjolnir/uniquenames.h>
 
-
 namespace valhalla {
 namespace mjolnir {
 
 using WayVector = std::vector<OSMWay>;
 using NodeRefVector = std::vector<uint64_t>;
-using RestrictionsVector = std::vector<OSMRestriction>;
+using RestrictionsMap = std::unordered_multimap<uint64_t, OSMRestriction>;
+using OSMNodeMap = std::unordered_map<uint64_t, OSMNode>;
+using OSMStringMap = std::unordered_map<uint64_t, std::string>;
 
 enum class OSMType : uint8_t {
     kNode,
@@ -37,26 +37,26 @@ struct OSMData {
   // Stores all the ways that are part of the road network
   WayVector ways;
 
-  // Stores simple restrictions.
-  RestrictionsVector restrictions;
+  // Stores simple restrictions. Indexed by the from way Id.
+  RestrictionsMap restrictions;
 
   // Node references
   NodeRefVector noderefs;
 
-  // Map that stores all the nodes read
-  std::unordered_map<uint64_t, OSMNode> nodes;
+  // Map that stores all the nodes read. Indexed by OSM node Id.
+  OSMNodeMap nodes;
 
   // Map that stores all the ref info on a node
-  std::unordered_map<uint64_t, std::string> node_ref;
+  OSMStringMap node_ref;
 
-  // Map that stores all the exit to info on a node
-  std::unordered_map<uint64_t, std::string> node_exit_to;
+  // Map that stores all the exit_to info on a node
+  OSMStringMap node_exit_to;
 
   // Map that stores all the name info on a node
-  std::unordered_map<uint64_t, std::string> node_name;
+  OSMStringMap node_name;
 
   // Map that stores an updated ref for a way
-  std::unordered_map<uint64_t, std::string> way_ref;
+  OSMStringMap way_ref;
 
   // References
   UniqueNames ref_offset_map;

--- a/valhalla/mjolnir/osmrestriction.h
+++ b/valhalla/mjolnir/osmrestriction.h
@@ -2,14 +2,15 @@
 #define VALHALLA_MJOLNIR_OSMRESTRICTION_H
 
 #include <valhalla/baldr/graphconstants.h>
-
-using namespace valhalla::baldr;
+#include <valhalla/baldr/graphid.h>
 
 namespace valhalla {
 namespace mjolnir {
 
 /**
- * OSM restriction information. Result of parsing OSM simple restrictions found in the relations.
+ * OSM restriction information. Result of parsing OSM simple restrictions
+ * found in the relations. Restrictions are stored in a multimap keyed by
+ * the Id of the "from" way of the restriction.
  */
 class OSMRestriction {
  public:
@@ -26,32 +27,32 @@ class OSMRestriction {
   /**
    * Set the restriction type
    */
-  void set_type(RestrictionType type);
+  void set_type(baldr::RestrictionType type);
 
   /**
    * Get the restriction type
    */
-  RestrictionType type() const;
+  baldr::RestrictionType type() const;
 
   /**
    * Set the day on
    */
-  void set_day_on(DOW dow);
+  void set_day_on(baldr::DOW dow);
 
   /**
    * Get the day on
    */
-  DOW day_on() const;
+  baldr::DOW day_on() const;
 
   /**
    * Set the day off
    */
-  void set_day_off(DOW dow);
+  void set_day_off(baldr::DOW dow);
 
   /**
    * Get the day off
    */
-  DOW day_off() const;
+  baldr::DOW day_off() const;
 
   /**
    * Set the hour on
@@ -94,24 +95,24 @@ class OSMRestriction {
   uint32_t minute_off() const;
 
   /**
-   * Set the from way id
-   */
-  void set_from(uint64_t from);
-
-  /**
-   * Get the from way id
-   */
-  uint64_t from() const;
-
-  /**
-   * Set the via id
+   * Set the via OSM node id
    */
   void set_via(uint64_t via);
 
   /**
-   * Get the via id
+   * Set the via node GraphId.
+   */
+  void set_via(const baldr::GraphId& id);
+
+  /**
+   * Get the via OSM node id.
    */
   uint64_t via() const;
+
+  /**
+   * Get the via GraphId
+   */
+  const baldr::GraphId& via_graphid() const;
 
   /**
    * Set the to way id
@@ -124,16 +125,18 @@ class OSMRestriction {
   uint64_t to() const;
 
  protected:
+  // Via is a node. When parsing OSM this is stored as an OSM node Id.
+  // It later gets changed into a GraphId.
+  union ViaNode {
+    baldr::GraphId id;
+    uint64_t osmid;
+  };
+  ViaNode via_;
 
-  //from is a way
-  uint64_t from_;
-
-  //For now, via is of type node.
-  uint64_t via_;
-
-  //to is a way
+  // to is a way - uses OSM way Id.
   uint64_t to_;
 
+  // Type and time information of the restriction.
   struct Attributes {
     uint32_t type_        : 4;
     uint32_t day_on_      : 3;
@@ -144,7 +147,6 @@ class OSMRestriction {
     uint32_t minute_off_  : 6;
   };
   Attributes attributes_;
-
 };
 
 }

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -8,8 +8,6 @@
 #include <valhalla/baldr/graphconstants.h>
 #include <valhalla/mjolnir/uniquenames.h>
 
-using namespace valhalla::baldr;
-
 namespace valhalla {
 namespace mjolnir {
 
@@ -69,12 +67,6 @@ class OSMWay {
    * Get the number of nodes for this way.
    */
   uint32_t node_count() const;
-
-  /**
-   * Get the list of nodes for this way.
-   * @return  Returns nodes
-   */
- // const std::vector<uint64_t>& nodes() const;
 
   /**
    * Sets the speed
@@ -380,25 +372,25 @@ class OSMWay {
    * Sets the surface.
    * @param  surface
    */
-  void set_surface(const Surface surface);
+  void set_surface(const baldr::Surface surface);
 
   /**
    * Get the surface.
    * @return  Returns Surface.
    */
-  Surface surface() const;
+  baldr::Surface surface() const;
 
   /**
    * Sets the cycle lane.
    * @param  cyclelane
    */
-  void set_cyclelane(const CycleLane cyclelane);
+  void set_cyclelane(const baldr::CycleLane cyclelane);
 
   /**
    * Get the cycle lane.
    * @return  Returns CycleLane.
    */
-  CycleLane cyclelane() const;
+  baldr::CycleLane cyclelane() const;
 
   /**
    * Sets the number of lanes
@@ -476,26 +468,26 @@ class OSMWay {
    * Get the road class.
    * @return  Returns road class.
    */
-  RoadClass road_class() const;
+  baldr::RoadClass road_class() const;
 
   /**
    * Sets the road class.
    * @param  roadclass  Road Class/highway type.
    */
-  void set_road_class(const RoadClass roadclass);
+  void set_road_class(const baldr::RoadClass roadclass);
 
   /**
    * Sets the use tag.
    * @param  use       use. None Cycleway ParkingAisle, Driveway, Alley,
    *                        EmergencyAccess, DriveThru, Steps, and Other
    */
-  void set_use(const Use use);
+  void set_use(const baldr::Use use);
 
   /**
    * Get the use.
    * @return  Returns use.
    */
-  Use use() const;
+  baldr::Use use() const;
 
   /**
    * Sets the link tag.

--- a/valhalla/mjolnir/pbfparser.h
+++ b/valhalla/mjolnir/pbfparser.h
@@ -119,7 +119,7 @@ class PBFParser {
   size_t speed_assignment_count_;
 
   // List of the tile levels to be created
-  TileHierarchy tile_hierarchy_;
+  baldr::TileHierarchy tile_hierarchy_;
 
   // Lua Tag Transformation class
   LuaTagTransform lua_;

--- a/valhalla/mjolnir/signbuilder.h
+++ b/valhalla/mjolnir/signbuilder.h
@@ -2,10 +2,6 @@
 #define VALHALLA_MJOLNIR_SIGNBUILDER_H_
 
 #include <valhalla/baldr/sign.h>
-#include <valhalla/midgard/util.h>
-
-using namespace valhalla::midgard;
-using namespace valhalla::baldr;
 
 namespace valhalla {
 namespace mjolnir {

--- a/valhalla/mjolnir/turnrestrictionbuilder.h
+++ b/valhalla/mjolnir/turnrestrictionbuilder.h
@@ -1,0 +1,37 @@
+#ifndef VALHALLA_MJOLNIR_TURNRESTRICTIONBUILDER_H_
+#define VALHALLA_MJOLNIR_TURNRESTRICTIONBUILDER_H_
+
+#include <valhalla/baldr/turnrestriction.h>
+
+namespace valhalla {
+namespace mjolnir {
+
+/**
+ * Generic sign builder. Encapsulates the sign type and the associated
+ * text index. Includes the directed edge index - signs are accessed via
+ * the directed edge to which they apply. Makes base class writable.
+ */
+class TurnRestrictionBuilder : public baldr::TurnRestriction {
+ public:
+  /**
+   * Constructor with arguments.
+   * @param  idx  Index of the directed edge the turn restriction is from.
+   * @param  type Type of turn restriction.
+   * @param  restriction_mask  bit mask where bits set to 1 indicate
+   *            a restricted turn based on index of the outbound directed
+   *            edge at the end node of this directed edge.
+   */
+  TurnRestrictionBuilder(const uint32_t idx, const baldr::RestrictionType type,
+                  const uint32_t restriction_mask);
+
+  /**
+   * Set the directed edge index.
+   * @param  idx  Directed edge index.
+   */
+  void set_edgeindex(const uint32_t idx);
+};
+
+}
+}
+
+#endif  // VALHALLA_MJOLNIR_TURNRESTRICTIONBUILDER_H_

--- a/valhalla/mjolnir/uniquenames.h
+++ b/valhalla/mjolnir/uniquenames.h
@@ -9,6 +9,8 @@
 namespace valhalla {
 namespace mjolnir {
 
+using NamesMap = std::unordered_map<std::string, uint32_t>;
+
 /**
  * Class to hold a list of unique names and indexes to them.
  */
@@ -52,10 +54,10 @@ class UniqueNames {
 
  protected:
   // Map of names to indexes
-  std::unordered_map<std::string, uint32_t> names_;
+  NamesMap names_;
 
   // List of entries into the map
-  using nameiter = std::unordered_map<std::string, uint32_t>::iterator;
+  using nameiter = NamesMap::iterator;
   std::vector<nameiter> indexes_;
 };
 


### PR DESCRIPTION
Lots of changes to identify simple TRs and make it so they can be added. Next need to actually add them and update the hierarchy builder to properly update them and handle them during shortcut creation.