### PR TITLE
Add simple turn restrictions (part 2)

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -278,7 +278,9 @@ void GraphBuilder::UpdateRestrictions(OSMData& osmdata) {
   for (auto& rst : osmdata.restrictions) {
     const auto nd = nodes_.find(rst.second.via());
     if (nd == nodes_.end()) {
-      LOG_INFO("Restriction Via node on a non-graph node");
+      // TODO - log these as data issues??
+      LOG_ERROR("Restriction Via node on a non-graph node: from wayid = "
+           + std::to_string(rst.first));
     } else {
       rst.second.set_via(nd->second);
     }
@@ -698,7 +700,9 @@ bool CreateSimpleTurnRestriction(const uint64_t wayid, const uint32_t edgeindex,
     notype = true;
   }
   if (notype && onlytype) {
-    LOG_ERROR("Restrictions have both \"only\" and \"no\" types - skip them!");
+    // TODO - log these as data issues??
+    LOG_ERROR("Restrictions have both \"only\" and \"no\" types. From wayid = "
+          + std::to_string(wayid));
     return false;
   }
 

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -688,7 +688,7 @@ bool CreateSimpleTurnRestriction(const uint64_t wayid, const uint32_t edgeindex,
     return false;
   }
 
-  // TODO - cannot mix types (no and only!)
+  // Cannot mix types (no and only!). Log an error/issue.
   bool notype = false;
   bool onlytype = false;
   for (const auto& tr : trs) {

--- a/src/mjolnir/graphoptimizer.cc
+++ b/src/mjolnir/graphoptimizer.cc
@@ -54,7 +54,7 @@ void GraphOptimizer::Optimize() {
       }
     }
   }
-  LOG_INFO("DONE");
+  LOG_INFO("Validation of tiles is done");
 
   for (auto tile_level :  tile_hierarchy_.levels()) {
     dupcount_ = 0;

--- a/src/mjolnir/graphoptimizer.cc
+++ b/src/mjolnir/graphoptimizer.cc
@@ -24,6 +24,38 @@ GraphOptimizer::GraphOptimizer(const boost::property_tree::ptree& pt)
 void GraphOptimizer::Optimize() {
   // Iterate through all levels and all tiles.
   // TODO - concurrency
+  LOG_INFO("GraphOptimizer - validate tiles first");
+
+  // Validate signs
+  for (auto tile_level :  tile_hierarchy_.levels()) {
+    uint32_t level = (uint32_t)tile_level.second.level;
+    uint32_t ntiles = tile_level.second.tiles.TileCount();
+    for (uint32_t tileid = 0; tileid < ntiles; tileid++) {
+      // Get the graph tile. Skip if no tile exists (common case)
+      const GraphTile tile(tile_hierarchy_, GraphId(tileid, level, 0));
+      if (tile.size() == 0) {
+        continue;
+      }
+      for (uint32_t i = 0; i < tile.header()->nodecount(); i++) {
+        const NodeInfo* nodeinfo = tile.node(i);
+
+        // Go through directed edges and update data
+        uint32_t idx = nodeinfo->edge_index();
+        for (uint32_t j = 0, n = nodeinfo->edge_count(); j < n; j++, idx++) {
+          const DirectedEdge* directededge = tile.directededge(idx);
+
+          // Validate signs
+          if (directededge->exitsign()) {
+            if (tile.GetSigns(idx).size() == 0) {
+              LOG_ERROR("Directed edge marked as having signs but none found");
+            }
+          }
+        }
+      }
+    }
+  }
+  LOG_INFO("DONE");
+
   for (auto tile_level :  tile_hierarchy_.levels()) {
     dupcount_ = 0;
     uint32_t level = (uint32_t)tile_level.second.level;

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -69,9 +69,7 @@ void GraphTileBuilder::StoreTileData(const baldr::TileHierarchy& hierarchy,
     // Write the signs
     file.write(reinterpret_cast<const char*>(&signs_builder_[0]),
                signs_builder_.size() * sizeof(SignBuilder));
-if (header_builder_.turnrestriction_count() > 0) {
-  LOG_INFO("Write Tile with " + std::to_string(turnrestriction_builder_.size()) + " trs");
-}
+
     // Write the turn restrictions
     file.write(reinterpret_cast<const char*>(&turnrestriction_builder_[0]),
                turnrestriction_builder_.size() * sizeof(TurnRestrictionBuilder));
@@ -342,6 +340,13 @@ SignBuilder& GraphTileBuilder::sign(const size_t idx) {
   if (idx < header_->signcount())
     return static_cast<SignBuilder&>(signs_[idx]);
   throw std::runtime_error("GraphTileBuilder sign index is out of bounds");
+}
+
+// Gets a non-const turn restriction (builder) from existing tile data.
+TurnRestrictionBuilder& GraphTileBuilder::turnrestriction(const size_t idx) {
+  if (idx < header_->turnrestriction_count())
+    return static_cast<TurnRestrictionBuilder&>(turnrestrictions_[idx]);
+  throw std::runtime_error("GraphTileBuilder turn restriction index is out of bounds");
 }
 
 }

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -44,11 +44,13 @@ void GraphTileBuilder::StoreTileData(const baldr::TileHierarchy& hierarchy,
     header_builder_.set_nodecount(nodes_builder_.size());
     header_builder_.set_directededgecount(directededges_builder_.size());
     header_builder_.set_signcount(signs_builder_.size());
+    header_builder_.set_turnrestriction_count(turnrestriction_builder_.size());
     header_builder_.set_edgeinfo_offset(
         (sizeof(GraphTileHeaderBuilder))
             + (nodes_builder_.size() * sizeof(NodeInfoBuilder))
-            + (directededges_builder_.size() * sizeof(DirectedEdgeBuilder)
-            + (signs_builder_.size() * sizeof(SignBuilder))));
+            + (directededges_builder_.size() * sizeof(DirectedEdgeBuilder))
+            + (signs_builder_.size() * sizeof(SignBuilder))
+            + (turnrestriction_builder_.size() * sizeof(TurnRestrictionBuilder)));
     header_builder_.set_textlist_offset(
         header_builder_.edgeinfo_offset() + edge_info_offset_);
 
@@ -67,7 +69,9 @@ void GraphTileBuilder::StoreTileData(const baldr::TileHierarchy& hierarchy,
     // Write the signs
     file.write(reinterpret_cast<const char*>(&signs_builder_[0]),
                signs_builder_.size() * sizeof(SignBuilder));
-
+if (header_builder_.turnrestriction_count() > 0) {
+  LOG_INFO("Write Tile with " + std::to_string(turnrestriction_builder_.size()) + " trs");
+}
     // Write the turn restrictions
     file.write(reinterpret_cast<const char*>(&turnrestriction_builder_[0]),
                turnrestriction_builder_.size() * sizeof(TurnRestrictionBuilder));
@@ -231,6 +235,11 @@ void GraphTileBuilder::AddSigns(const uint32_t idx,
                   existing_text_offset->second);
     }
   }
+}
+
+// Add simple turn restriction.
+void GraphTileBuilder::AddTurnRestriction(const TurnRestrictionBuilder& tr) {
+  turnrestriction_builder_.push_back(tr);
 }
 
 uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,

--- a/src/mjolnir/pbfparser.cc
+++ b/src/mjolnir/pbfparser.cc
@@ -594,13 +594,9 @@ void PBFParser::relation_callback(uint64_t osmid, const Tags &tags,
           hasRestriction = true;
           restriction.set_type(type);
           break;
-        case RestrictionType::kNone:
-        case RestrictionType::kNoEntry:
-        case RestrictionType::kNoExit:
         default:
-          // kNoEntry and kNoExit not supported in for simple restrictions.
+          // kNoEntry and kNoExit not supported.
           return;
-          break;
       }
     }
     //sample with date time.  1168738

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -105,12 +105,10 @@ class GraphTileBuilder : public baldr::GraphTile {
                 const std::vector<baldr::SignInfo>& signs);
 
   /**
-   * Add simple turn restrictions.
-   * @param  idx  Directed edge index.
-   * @param  trs  Turn restrictions
+   * Add simple turn restriction.
+   * @param  tr  Turn restriction (includes the directed edge index)
    */
-  void AddTurnRestrictions(const uint32_t idx,
-                const std::vector<baldr::TurnRestriction>& trs);
+  void AddTurnRestriction(const TurnRestrictionBuilder& tr);
 
   /**
    * Add edge info to the tile.

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -138,6 +138,13 @@ class GraphTileBuilder : public baldr::GraphTile {
    */
   SignBuilder& sign(const size_t idx);
 
+  /**
+   * Gets a non-const turn restriction (builder) from existing tile data.
+   * @param  idx  Index of the turn restriction (index in the array, not the
+   *              directed edge index) within the tile.
+   */
+  TurnRestrictionBuilder& turnrestriction(const size_t idx);
+
  protected:
 
   struct EdgeTupleHasher {


### PR DESCRIPTION
This PR actually adds them to the tile. HierarchyBuilder updates edge indexes for the TRs during hierarchy building. All that is left to do is to update TRs on the arterial and highway levels and to figure out how they impact shortcut edges (not that these are trivial tasks!)