### PR TITLE
Set methods to reflect changes to NodeInfo and DirectedEdge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ test-driver
 test/test_config
 test/directededgebuilder
 test/edgeinfobuilder
+test/nodeinfobuilder
 test/uniquenames
 test/idtable
 test/graphtilebuilder

--- a/Makefile.am
+++ b/Makefile.am
@@ -122,6 +122,7 @@ check_PROGRAMS = \
 	test/graphtilebuilder \
 	test/graphbuilder \
         test/graphparser \
+	test/nodeinfobuilder \
         test/refs \
 	test/signinfo 
 test_directededgebuilder_SOURCES = test/directededgebuilder.cc test/test.cc
@@ -130,6 +131,9 @@ test_directededgebuilder_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS
 test_edgeinfobuilder_SOURCES = test/edgeinfobuilder.cc test/test.cc
 test_edgeinfobuilder_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 test_edgeinfobuilder_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_mjolnir.la
+test_nodeinfobuilder_SOURCES = test/nodeinfobuilder.cc test/test.cc
+test_nodeinfobuilder_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
+test_nodeinfobuilder_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_mjolnir.la
 test_uniquenames_SOURCES = test/uniquenames.cc test/test.cc
 test_uniquenames_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 test_uniquenames_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_mjolnir.la

--- a/src/mjolnir/nodeinfobuilder.cc
+++ b/src/mjolnir/nodeinfobuilder.cc
@@ -211,8 +211,9 @@ void NodeInfoBuilder::set_heading(const uint32_t localidx, const float heading) 
    } else if (localidx > kMaxLocalDriveable) {
      LOG_WARN("Local index exceeds max in set_heading, skip");
    } else {
-     // Has to be 64 bit!
-     uint32_t hdg = static_cast<uint32_t>((heading * 0.5f) + 0.5f);
+     // Has to be 64 bit! Round values above 359 to 0 degrees.
+     uint32_t hdg = (heading > 359.0) ?
+                     0 : static_cast<uint32_t>((heading * 0.5f) + 0.5f);
      headings_ |= static_cast<uint64_t>(hdg) << static_cast<uint64_t>(localidx * 8);
    }
 }

--- a/test/nodeinfobuilder.cc
+++ b/test/nodeinfobuilder.cc
@@ -1,0 +1,92 @@
+#include "test.h"
+
+#include <vector>
+#include <iostream>
+#include <fstream>
+
+#include <valhalla/baldr/graphid.h>
+#include <valhalla/baldr/nodeinfo.h>
+#include "mjolnir/nodeinfobuilder.h"
+#include <boost/shared_array.hpp>
+#include <memory>
+
+using namespace std;
+using namespace valhalla::baldr;
+using namespace valhalla::mjolnir;
+
+namespace {
+
+void TestWriteRead() {
+  // Test building NodeInfo and reading back values
+  NodeInfoBuilder nodebuilder;
+
+  // Headings get rounded off to nearest 2 degrees
+  nodebuilder.set_heading(0, 266.5f);
+  nodebuilder.set_heading(3, 185.5f);
+  nodebuilder.set_heading(2, 32.5f);
+  nodebuilder.set_heading(6, 145.5f);
+  if (nodebuilder.heading(0) != 266) {
+    throw runtime_error("NodeInfo heading for localidx 0 test failed " +
+                        std::to_string(nodebuilder.heading(0)));
+  }
+  if (nodebuilder.heading(2) != 32) {
+     throw runtime_error("NodeInfo heading for localidx 2 test failed " +
+                         std::to_string(nodebuilder.heading(2)));
+  }
+  if (nodebuilder.heading(3) != 186) {
+    throw runtime_error("NodeInfo heading for localidx 3 test failed " +
+                        std::to_string(nodebuilder.heading(5)));
+  }
+  if (nodebuilder.heading(6) != 146) {
+    throw runtime_error("NodeInfo heading for localidx 6 test failed " +
+                        std::to_string(nodebuilder.heading(6)));
+  }
+
+  nodebuilder.set_name_consistency(0, 4, true);
+  nodebuilder.set_name_consistency(3, 1, false);
+  nodebuilder.set_name_consistency(2, 7, true);
+  nodebuilder.set_name_consistency(6, 6, true);
+  if (nodebuilder.name_consistency(0, 4) != true) {
+    throw runtime_error("NodeInfo name_consistency for 0,4 test failed");
+  }
+  if (nodebuilder.name_consistency(4, 0) != true) {
+    throw runtime_error("NodeInfo name_consistency for 4,0 test failed");
+  }
+  if (nodebuilder.name_consistency(1, 3) != false) {
+    throw runtime_error("NodeInfo name_consistency for 1,3 test failed");
+  }
+  if (nodebuilder.name_consistency(7, 2) != true) {
+    throw runtime_error("NodeInfo name_consistency for 7,2 test failed");
+  }
+  if (nodebuilder.name_consistency(6, 6) != true) {
+    throw runtime_error("NodeInfo name_consistency for 6,6 test failed");
+  }
+
+  nodebuilder.set_local_driveability(3, Driveability::kBoth);
+  nodebuilder.set_local_driveability(5, Driveability::kNone);
+  nodebuilder.set_local_driveability(7, Driveability::kForward);
+  nodebuilder.set_local_driveability(1, Driveability::kBackward);
+  if (nodebuilder.local_driveability(3) != Driveability::kBoth) {
+    throw runtime_error("NodeInfo local_driveability 3 test failed");
+  }
+  if (nodebuilder.local_driveability(5) != Driveability::kNone) {
+    throw runtime_error("NodeInfo local_driveability 5 test failed");
+  }
+  if (nodebuilder.local_driveability(7) != Driveability::kForward) {
+    throw runtime_error("NodeInfo local_driveability 5 test failed");
+  }
+  if (nodebuilder.local_driveability(1) != Driveability::kBackward) {
+    throw runtime_error("NodeInfo local_driveability 5 test failed");
+  }
+}
+
+}
+
+int main() {
+  test::suite suite("nodeinfobuilder");
+
+  // Write to file and read into NodeInfoEdge
+  suite.test(TEST_CASE(TestWriteRead));
+
+  return suite.tear_down();
+}

--- a/valhalla/mjolnir/directededgebuilder.h
+++ b/valhalla/mjolnir/directededgebuilder.h
@@ -420,12 +420,12 @@ class DirectedEdgeBuilder : public baldr::DirectedEdge {
   void set_turntype(const uint32_t localidx, const Turn::Type turntype);
 
   /**
-   * Set the consistent name flag between this edge and the
-   * prior edge given its local index (index of the inbound edge).
+   * Set the flag indicating there is an edge to the left, in between
+   * the from edge and this edge.
    * @param  localidx  Local index at the node of the inbound edge.
-   * @param  consistent  true if there is a consistent name, false if not.
+   * @param  left      True if there is an edge to the left, false if not.
    */
-  void set_consistent_name(const uint32_t localidx, const bool consistent);
+  void set_edge_to_left(const uint32_t localidx, const bool left);
 
   /**
    * Set the stop impact when transitioning from the prior edge (given
@@ -435,7 +435,13 @@ class DirectedEdgeBuilder : public baldr::DirectedEdge {
    */
   void set_stopimpact(const uint32_t localidx, const uint32_t stopimpact);
 
-  // TODO - intersection transitions
+  /**
+   * Set the flag indicating there is an edge to the right, in between
+   * the from edge and this edge.
+   * @param  localidx  Local index at the node of the inbound edge.
+   * @param  right     True if there is an edge to the right, false if not.
+   */
+  void set_edge_to_right(const uint32_t localidx, const bool right);
 
 };
 

--- a/valhalla/mjolnir/nodeinfobuilder.h
+++ b/valhalla/mjolnir/nodeinfobuilder.h
@@ -97,6 +97,15 @@ class NodeInfoBuilder : public baldr::NodeInfo {
   void set_dst(const bool dst);
 
   /**
+   * Set the driveability of the local directed edge given a local
+   * edge index.
+   * @param  localidx  Local edge index.
+   * @param  d         Driveability (see graphconstants.h)
+   */
+  void set_local_driveability(const uint32_t localidx,
+                              const baldr::Driveability d);
+
+  /**
    * Set the relative density
    * @param  density  density.
    */
@@ -152,6 +161,24 @@ class NodeInfoBuilder : public baldr::NodeInfo {
    */
   void set_stop_id(const uint32_t stop_id);
 
+  /**
+   * Set the name consistency between a pair of local edges. This is limited
+   * to the first 8 local edge indexes.
+   * @param  from  Local index of the from edge.
+   * @param  to    Local index of the to edge.
+   * @param  c     Are names consistent between the 2 edges?
+   */
+  void set_name_consistency(const uint32_t from, const uint32_t to,
+                            const bool c);
+
+  /**
+   * Set the heading of the local edge given its local index. Supports
+   * up to 8 local edges. Headings are stored rounded off to 2 degree
+   * values.
+   * @param  localidx  Local edge index.
+   * @param  heading   Heading relative to N (0-360 degrees).
+   */
+  void set_heading(const uint32_t localidx, const float heading);
 };
 
 }


### PR DESCRIPTION
Added some tests due to bit field manipulation (and added a convenience method to the builders to overwrite a set of bits).