### PR TITLE
Updates to shortcut and superseded to make them a mask rather than bool

### DIFF
--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -475,7 +475,6 @@ void DirectedEdgeBuilder::set_opp_local_idx(const uint32_t idx) {
 
 // Set the flag for whether this edge represents a shortcut between 2 nodes.
 void DirectedEdgeBuilder::set_shortcut(const uint32_t shortcut) {
-  // TODO - check against max
   if (shortcut > kMaxShortcutsFromNode) {
     LOG_ERROR("Exceeding max shortcut edges from a node: " + std::to_string(shortcut));
   } else {

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -215,28 +215,6 @@ void DirectedEdgeBuilder::set_traffic_signal(const bool signal) {
   attributes_.traffic_signal = signal;
 }
 
-// Set the flag for whether this edge represents a transition up one level
-// in the hierarchy.
-void DirectedEdgeBuilder::set_trans_up(const bool trans_up) {
-  attributes_.trans_up = trans_up;
-}
-
-// Set the flag for whether this edge represents a transition down one level
-// in the hierarchy.
-void DirectedEdgeBuilder::set_trans_down(const bool trans_down) {
-  attributes_.trans_down = trans_down;
-}
-
-// Set the flag for whether this edge represents a shortcut between 2 nodes.
-void DirectedEdgeBuilder::set_shortcut(const bool shortcut) {
-  attributes_.shortcut = shortcut;
-}
-
-// Set the flag for whether this edge is superseded by a shortcut edge.
-void DirectedEdgeBuilder::set_superseded(const bool superseded) {
-  attributes_.superseded = superseded;
-}
-
 // Set the forward flag. Tells if this directed edge is stored forward
 // in edgeinfo (true) or reverse (false).
 void DirectedEdgeBuilder::set_forward(const bool forward) {
@@ -268,18 +246,6 @@ void DirectedEdgeBuilder::set_bikenetwork(const uint32_t bikenetwork) {
     attributes_.bikenetwork = 0;
   } else {
     attributes_.bikenetwork = bikenetwork;
-  }
-}
-
-// Set the index of the directed edge on the local level of the graph
-// hierarchy. This is used for turn restrictions so the edges can be
-// identified on the different levels.
-void DirectedEdgeBuilder::set_localedgeidx(const uint32_t idx) {
-  if (idx > kMaxEdgesPerNode) {
-    LOG_ERROR("Local Edge Index exceeds max: " + std::to_string(idx));
-    attributes_.localedgeidx = kMaxEdgesPerNode;
-  } else {
-    attributes_.localedgeidx = idx;
   }
 }
 
@@ -316,19 +282,6 @@ void DirectedEdgeBuilder::set_use(const Use use) {
 void DirectedEdgeBuilder::set_speed_type(const SpeedType speed_type) {
   attributes_.speed_type = static_cast<uint8_t>(speed_type);
 }
-
-// Set the index of the opposing directed edge on the local hierarchy level
-// at the end node of this directed edge. Only stored for the first 8 edges
-// so it can be used for edge transition costing.
-void DirectedEdgeBuilder::set_opp_local_idx(const uint32_t idx) {
-  if (idx > kMaxEdgesPerNode) {
-    LOG_ERROR("Exceeding max edges in opposing local index: " + std::to_string(idx));
-    attributes_.opp_local_idx = kMaxEdgesPerNode;
-  } else {
-    attributes_.opp_local_idx = idx;
-  }
-}
-
 
 // Set all forward access modes to true (used for transition edges)
 void DirectedEdgeBuilder::set_all_forward_access() {
@@ -495,6 +448,62 @@ void DirectedEdgeBuilder::set_edge_to_right(const uint32_t localidx,
                                 right, localidx, 1);
   }
 }
+
+// Set the index of the directed edge on the local level of the graph
+// hierarchy. This is used for turn restrictions so the edges can be
+// identified on the different levels.
+void DirectedEdgeBuilder::set_localedgeidx(const uint32_t idx) {
+  if (idx > kMaxEdgesPerNode) {
+    LOG_ERROR("Local Edge Index exceeds max: " + std::to_string(idx));
+    hierarchy_.localedgeidx = kMaxEdgesPerNode;
+  } else {
+    hierarchy_.localedgeidx = idx;
+  }
+}
+
+// Set the index of the opposing directed edge on the local hierarchy level
+// at the end node of this directed edge. Only stored for the first 8 edges
+// so it can be used for edge transition costing.
+void DirectedEdgeBuilder::set_opp_local_idx(const uint32_t idx) {
+  if (idx > kMaxEdgesPerNode) {
+    LOG_ERROR("Exceeding max edges in opposing local index: " + std::to_string(idx));
+    hierarchy_.opp_local_idx = kMaxEdgesPerNode;
+  } else {
+    hierarchy_.opp_local_idx = idx;
+  }
+}
+
+// Set the flag for whether this edge represents a shortcut between 2 nodes.
+void DirectedEdgeBuilder::set_shortcut(const uint32_t shortcut) {
+  // TODO - check against max
+  if (shortcut > kMaxShortcutsFromNode) {
+    LOG_ERROR("Exceeding max shortcut edges from a node: " + std::to_string(shortcut));
+  } else {
+    hierarchy_.shortcut = (1 << (shortcut-1));
+  }
+}
+
+// Set the flag for whether this edge is superseded by a shortcut edge.
+void DirectedEdgeBuilder::set_superseded(const uint32_t superseded) {
+  if (superseded > kMaxShortcutsFromNode) {
+      LOG_ERROR("Exceeding max shortcut edges from a node: " + std::to_string(superseded));
+  } else {
+    hierarchy_.superseded = (1 << (superseded-1));
+  }
+}
+
+// Set the flag for whether this edge represents a transition up one level
+// in the hierarchy.
+void DirectedEdgeBuilder::set_trans_up(const bool trans_up) {
+  hierarchy_.trans_up = trans_up;
+}
+
+// Set the flag for whether this edge represents a transition down one level
+// in the hierarchy.
+void DirectedEdgeBuilder::set_trans_down(const bool trans_down) {
+  hierarchy_.trans_down = trans_down;
+}
+
 
 }
 }

--- a/src/mjolnir/graphoptimizer.cc
+++ b/src/mjolnir/graphoptimizer.cc
@@ -125,10 +125,10 @@ uint32_t GraphOptimizer::GetOpposingEdgeIndex(const GraphId& startnode,
   const DirectedEdge* directededge = tile->directededge(
               nodeinfo->edge_index());
   for (uint32_t i = 0; i < nodeinfo->edge_count(); i++, directededge++) {
-    // End node must match the start node, shortcut flag must match
+    // End node must match the start node, shortcut (bool) must match
     // and lengths must be close...
     if (directededge->endnode() == startnode &&
-        edge.shortcut() == directededge->shortcut() &&
+        static_cast<bool>(edge.shortcut()) == static_cast<bool>(directededge->shortcut()) &&
         directededge->length() == edge.length()) {
       if (opp_index != absurd_index) {
         dupcount_++;
@@ -159,7 +159,7 @@ uint32_t GraphOptimizer::GetOpposingEdgeIndex(const GraphId& startnode,
         LOG_WARN("   No regular edges found from end node");
       }
     }
-    return 31;  // TODO - what value to return that will not impact routes?
+    return kMaxEdgesPerNode;
   }
   return opp_index;
 }

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -529,14 +529,6 @@ void HierarchyBuilder::AddShortcutEdges(
       newedge.set_length(length);
       newedge.set_endnode(nodeb);
 
-      // Set this as a shortcut edge. Add it to the shortcut map (associates
-      // the base edge index to the shortcut index). Remove superseded
-      // mask that may have been copied from base level directed edge
-      shortcuts[i] = shortcut;
-      newedge.set_shortcut(shortcut);
-      newedge.set_superseded(0);
-      shortcut++;
-
       if (newedge.exitsign()) {
         LOG_ERROR("Shortcut edge with exit signs");
       }
@@ -547,10 +539,19 @@ if (nodea.level() == 0) {
      % nodea % baseni->latlng().lat() % baseni->latlng().lng() % nodeb).str());
 }
 **/
-
-      // Add directed edge
-      if (shortcut <= kMaxShortcutsFromNode) {
+      // Add shortcut directed edge (if we have not reached max per node)
+      if (shortcut < kMaxShortcutsFromNode) {
+        // Add to the shortcut map (associates the base edge index to the
+        // shortcut index). Remove superseded mask that may have been copied
+        // from base level directed edge
+        shortcuts[i] = shortcut+1;
+        newedge.set_shortcut(shortcut+1);
+        newedge.set_superseded(0);
+        shortcut++;
         directededges.emplace_back(std::move(newedge));
+      } else {
+        LOG_INFO("Skip adding shortcut at " + std::to_string(baseni->latlng().lat()) +
+                 "," + std::to_string(baseni->latlng().lng()));
       }
     }
   }

--- a/valhalla/mjolnir/directededgebuilder.h
+++ b/valhalla/mjolnir/directededgebuilder.h
@@ -190,44 +190,6 @@ class DirectedEdgeBuilder : public baldr::DirectedEdge {
   void set_traffic_signal(const bool signal);
 
   /**
-   * Set the flag for whether this edge represents a transition up one level
-   * in the hierarchy. Transition edges move between nodes in different levels
-   * of the hierarchy but have no length or other attribution. An upward
-   * transition is a transition from a minor road hierarchy (local) to more
-   * major (arterial).
-   * @param  trans_up  True if the edge is a transition from a lower level
-   *          to a higher (false if not).
-   */
-  void set_trans_up(const bool trans_up);
-
-   /**
-    * Set the flag for whether this edge represents a transition down one level
-    * in the hierarchy. Transition edges move between nodes in different levels
-    * of the hierarchy but have no length or other attribution. A downward
-    * transition is a transition from a major road hierarchy (highway) to more
-    * minor (arterial).
-    * @param   trans_down  True if the edge is a transition from an upper level
-    *          to a lower (false if not).
-    */
-   void set_trans_down(const bool trans_down);
-
-  /**
-   * Set the flag for whether this edge represents a shortcut between 2 nodes.
-   * Shortcuts bypass nodes that only connect to lower levels in the hierarchy
-   * (other than the 1-2 higher level edges that superseded by the shortcut).
-   * @param  shortcut  True if this edge is a shortcut edge, false if not.
-   */
-  void set_shortcut(const bool shortcut);
-
-  /**
-   * Set the flag for whether this edge is superseded by a shortcut edge.
-   * Superseded edges can be skipped unless downward transitions are allowed.
-   * @param  superseded True if this edge is part of a shortcut edge, false
-  *          if not.
-  */
-  void set_superseded(const bool superseded);
-
-  /**
    * Set the forward flag. Tells if this directed edge is stored forward
    * in edgeinfo (true) or reverse (false).
    * @param  forward  Forward flag.
@@ -263,14 +225,6 @@ class DirectedEdgeBuilder : public baldr::DirectedEdge {
   void set_bikenetwork(const uint32_t bikenetwork);
 
   /**
-   * Set the index of the directed edge on the local level of the graph
-   * hierarchy. This is used for turn restrictions so the edges can be
-   * identified on the different levels.
-   * @param idx The index of the edge on the local level.
-   */
-  void set_localedgeidx(const uint32_t idx);
-
-  /**
    * Sets the number of lanes
    * @param  lanecount  Number of lanes
    */
@@ -296,15 +250,6 @@ class DirectedEdgeBuilder : public baldr::DirectedEdge {
    * @param  speed_type  Returns the speed type.
    */
   void set_speed_type(const SpeedType speed_type);
-
-  /**
-    * Set the index of the opposing directed edge on the local hierarchy level
-    * at the end node of this directed edge. Only stored for the first 8 edges
-    * so it can be used for edge transition costing.
-    * @param localidx  The index of the opposing directed edge on the local
-    *                  hierarchy level at end node of this directed edge.
-    */
-  void set_opp_local_idx(const uint32_t localidx);
 
   /**
    * Set all forward access modes to true (used for transition edges)
@@ -442,6 +387,62 @@ class DirectedEdgeBuilder : public baldr::DirectedEdge {
    * @param  right     True if there is an edge to the right, false if not.
    */
   void set_edge_to_right(const uint32_t localidx, const bool right);
+
+  /**
+   * Set the index of the directed edge on the local level of the graph
+   * hierarchy. This is used for turn restrictions so the edges can be
+   * identified on the different levels.
+   * @param idx The index of the edge on the local level.
+   */
+  void set_localedgeidx(const uint32_t idx);
+
+  /**
+   * Set the index of the opposing directed edge on the local hierarchy level
+   * at the end node of this directed edge. Only stored for the first 8 edges
+   * so it can be used for edge transition costing.
+   * @param localidx  The index of the opposing directed edge on the local
+   *                  hierarchy level at end node of this directed edge.
+   */
+  void set_opp_local_idx(const uint32_t localidx);
+
+  /**
+   * Set the mask for whether this edge represents a shortcut between 2 nodes.
+   * Shortcuts bypass nodes that only connect to lower levels in the hierarchy
+   * (other than the 1-2 higher level edges that superseded by the shortcut).
+   * @param  shortcut  Mask indicating the edge that is superseded by
+   *                   the shortcut. 0 if not a shortcut.
+   */
+  void set_shortcut(const uint32_t shortcut);
+
+  /**
+   * Set the mask for whether this edge is superseded by a shortcut edge.
+   * Superseded edges can be skipped unless downward transitions are allowed.
+   * @param  superseded  Mask that matches the shortcut that supersedes this
+   *                     directed edge. 0 if not superseded by a shortcut.
+   */
+  void set_superseded(const uint32_t superseded);
+
+  /**
+   * Set the flag for whether this edge represents a transition up one level
+   * in the hierarchy. Transition edges move between nodes in different levels
+   * of the hierarchy but have no length or other attribution. An upward
+   * transition is a transition from a minor road hierarchy (local) to more
+   * major (arterial).
+   * @param  trans_up  True if the edge is a transition from a lower level
+   *          to a higher (false if not).
+   */
+  void set_trans_up(const bool trans_up);
+
+  /**
+   * Set the flag for whether this edge represents a transition down one level
+   * in the hierarchy. Transition edges move between nodes in different levels
+   * of the hierarchy but have no length or other attribution. A downward
+   * transition is a transition from a major road hierarchy (highway) to more
+   * minor (arterial).
+   * @param   trans_down  True if the edge is a transition from an upper level
+   *          to a lower (false if not).
+   */
+  void set_trans_down(const bool trans_down);
 
 };
 

--- a/valhalla/mjolnir/hierarchybuilder.h
+++ b/valhalla/mjolnir/hierarchybuilder.h
@@ -87,9 +87,6 @@ class HierarchyBuilder {
   // Mapping from base level node to new node
   std::unordered_map<uint64_t, baldr::GraphId> nodemap_;
 
-  // Mapping superseded edges
-  std::unordered_map<uint64_t, bool> supersededmap_;
-
   // Map of base edges forming potential shortcuts
   std::unordered_map<uint64_t, EdgePairs> contractions_;
 
@@ -139,13 +136,6 @@ class HierarchyBuilder {
   GraphId GetOpposingEdge(const GraphId& node, const DirectedEdge* edge);
 
   /**
-   * Is the edge superseded (used in a shortcut edge)?
-   * @param  edge   Base GraphId of the edge
-   * @return  Returns true if the edge is part of a shortcut, false if not.
-   */
-  bool IsSuperseded(const baldr::GraphId& edge) const;
-
-  /**
    * Form tiles in the new level
    * @param  base_level  Base level tile information
    * @param  new_level   Tile information for the new level.
@@ -162,7 +152,8 @@ class HierarchyBuilder {
                         const baldr::GraphTile* tile,
                         const baldr::RoadClass rcc,
                         GraphTileBuilder& tilebuilder,
-                        std::vector<DirectedEdgeBuilder>& directededges);
+                        std::vector<DirectedEdgeBuilder>& directededges,
+                        std::unordered_map<uint32_t, uint32_t>& shortcuts);
 
   /**
    * Connect edges on the shortcut. Appends shape.


### PR DESCRIPTION
Fix in hierarchy builder. Fix GraphOptimizer to only check if a shortcut (not its mask-but bool value saying if shortcut exists)