### PR TITLE
send graph nodes to file

### DIFF
--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -2,6 +2,8 @@
 #include <valhalla/baldr/nodeinfo.h>
 #include <valhalla/midgard/logging.h>
 
+#include <algorithm>
+
 namespace {
 
 /**
@@ -494,6 +496,13 @@ void DirectedEdgeBuilder::set_edge_to_right(const uint32_t localidx,
     stopimpact_.edge_to_right = OverwriteBits(stopimpact_.edge_to_right,
                                 right, localidx, 1);
   }
+}
+
+DirectedEdgeBuilder DirectedEdgeBuilder::flipped() const {
+  auto other = *this;
+  std::swap(other.forwardaccess_, other.reverseaccess_);
+  other.attributes_.forward = !other.attributes_.forward;
+  return other;
 }
 
 }

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -128,8 +128,9 @@ node_bundle collect_node_edges(const sequence<Node>::iterator& node_itr, sequenc
       bundle.edges.emplace_back(edge, edge_itr.position());
       bundle.node.attributes_.link_edge = bundle.node.attributes_.link_edge || edge.attributes.link;
       bundle.node.attributes_.non_link_edge = bundle.node.attributes_.non_link_edge || !edge.attributes.link;
+
     }
-    //dont add it again if its a loop
+    //add loop edge only once
     if(node.is_end() && node.end_of != node.start_of) {
       auto edge_itr = edges[node.end_of];
       auto edge = *edge_itr;
@@ -859,6 +860,15 @@ void BuildTileSet(const std::string& nodes_file, const std::string& edges_file,
             directededge.set_exitsign(true);
           }
 
+          // If this was a loop edge we need its twin because this node wont be encountered again
+          /*if(source == target) {
+            idx++;
+            n++;
+            auto flipped = directededge.flipped();
+            flipped.set_localedgeidx(n);
+            directededges.emplace_back();
+          }*/
+
           // Increment the directed edge index within the tile
           idx++;
           n++;
@@ -867,13 +877,10 @@ void BuildTileSet(const std::string& nodes_file, const std::string& edges_file,
         // Set the node lat,lng, index of the first outbound edge, and the
         // directed edge count from this edge and the best road class
         // from the node. Increment directed edge count.
-        NodeInfoBuilder nodebuilder(node_ll, directededgecount,
-                                    bundle.edges.size(), bestclass,
-                                    node.access_mask(), node.type(),
-                                    (bundle.edges.size() == 1),
-                                    node.traffic_signal());
+        NodeInfoBuilder nodebuilder(node_ll, directededgecount, n, bestclass, node.access_mask(),
+                                    node.type(), (n == 1), node.traffic_signal());
 
-        directededgecount += bundle.edges.size();
+        directededgecount += n;
 
         // Add node and directed edge information to the tile
         graphtile.AddNodeAndDirectedEdges(nodebuilder, directededges);

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -111,7 +111,8 @@ struct Node {
 // collect all the edges that start or end at this node
 struct node_bundle : Node {
   size_t node_count;
-  std::unordered_map<size_t, Edge> edges; //no duplicates (so loops be damned!)
+  //TODO: to enable two directed edges per loop edge turn this into an unordered_multimap or just a list of pairs
+  std::unordered_map<size_t, Edge> edges;
   node_bundle(const Node& other):Node(other), node_count(0){}
 };
 node_bundle collect_node_edges(const sequence<Node>::iterator& node_itr, sequence<Node>& nodes, sequence<Edge>& edges) {
@@ -844,7 +845,7 @@ void BuildTileSet(const std::string& nodes_file, const std::string& edges_file,
             directededge.set_exitsign(true);
           }
 
-          // If this was a loop edge we need its twin because this node wont be encountered again
+          //TODO: If this was a loop edge we need its twin because this node wont be encountered again
           /*if(source == target) {
             idx++;
             n++;

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -123,15 +123,11 @@ node_bundle collect_node_edges(const sequence<Node>::iterator& node_itr, sequenc
       auto edge_itr = edges[node.start_of];
       auto edge = *edge_itr;
       bundle.edges.emplace_back(edge, edge_itr.position());
-      bundle.node.attributes_.link_edge = bundle.node.attributes_.link_edge || edge.attributes.link;
-      bundle.node.attributes_.non_link_edge = bundle.node.attributes_.non_link_edge || !edge.attributes.link;
     }
     if(node.is_end()) {
       auto edge_itr = edges[node.end_of];
       auto edge = *edge_itr;
       bundle.edges.emplace_back(edge, edge_itr.position());
-      bundle.node.attributes_.link_edge = bundle.node.attributes_.link_edge || edge.attributes.link;
-      bundle.node.attributes_.non_link_edge = bundle.node.attributes_.non_link_edge || !edge.attributes.link;
     }
   }
   bundle.node_count = itr - node_itr;

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -1026,7 +1026,7 @@ void GraphBuilder::Build(const boost::property_tree::ptree& pt, OSMData& osmdata
   ReclassifyLinks(osmdata.ways_file, nodes_file, edges_file, stats);
 
   // Build tiles at the local level. Form connected graph from nodes and edges.
-  BuildLocalTiles(level, osmdata, nodes_file, edges_file, tiles, tile_hierarchy, stats);
+  BuildLocalTiles(threads, osmdata, nodes_file, edges_file, tiles, tile_hierarchy, stats);
 
   stats.LogStatistics();
 }

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -246,7 +246,7 @@ void ConstructEdges(const OSMData& osmdata, const std::string& nodes_file, const
   GraphId graphid;
   //so we can read ways and nodes and write edges
   sequence<OSMWay> ways(osmdata.ways_file, false);
-  sequence<OSMWayNode> way_nodes(osmdata.way_node_references_file, false);
+  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
   sequence<Edge> edges(edges_file, true);
   sequence<Node> nodes(nodes_file, true);
 
@@ -921,7 +921,7 @@ void BuildTileSet(const std::string& nodes_file, const std::string& edges_file,
   LOG_INFO("Thread " + thread_id + " started");
 
   sequence<OSMWay> ways(osmdata.ways_file, false);
-  sequence<OSMWayNode> way_nodes(osmdata.way_node_references_file, false);
+  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
   sequence<Edge> edges(edges_file, false);
   sequence<Node> nodes(nodes_file, false);
 

--- a/src/mjolnir/pbfadminparser.cc
+++ b/src/mjolnir/pbfadminparser.cc
@@ -26,7 +26,7 @@ constexpr uint64_t kMaxOSMNodeId = 4000000000;
 
 // Node equality
 const auto WayNodeEquals = [](const OSMWayNode& a, const OSMWayNode& b) {
-  return a.node_id == b.node_id;
+  return a.node.osmid == b.node.osmid;
 };
 
 struct admin_callback : public OSMPBF::Callback {
@@ -73,7 +73,8 @@ struct admin_callback : public OSMPBF::Callback {
       //update all the nodes that match it
       OSMWayNode way_node;
       sequence_element<OSMWayNode> element = (*way_nodes_)[current_way_node_index_];
-      while(current_way_node_index_ < way_nodes_->size() && (way_node = element = (*way_nodes_)[current_way_node_index_]).node_id == osmid) {
+      while(current_way_node_index_ < way_nodes_->size() && (way_node = element = (*way_nodes_)[current_way_node_index_]).node.osmid == osmid) {
+        way_node.node.osmid = osmid;
         way_node.node.lng = static_cast<float>(lng);
         way_node.node.lat = static_cast<float>(lat);
         element = way_node;
@@ -112,7 +113,7 @@ struct admin_callback : public OSMPBF::Callback {
     for (size_t i = 0; i < nodes.size(); ++i) {
       const auto& node = nodes[i];
       //keep the node
-      way_nodes_->push_back({node, ways_->size(), i});
+      way_nodes_->push_back({{node}, ways_->size(), i});
       ++osmdata_.node_count;
       // Mark the nodes that we will care about when processing nodes
       shape_.set(node);
@@ -244,7 +245,7 @@ OSMData PBFAdminParser::Parse(const boost::property_tree::ptree& pt, const std::
     sequence<OSMWayNode> way_nodes(osmdata.way_node_references_file, false);
     way_nodes.sort(
       [](const OSMWayNode& a, const OSMWayNode& b){
-        return a.node_id < b.node_id;
+        return a.node.osmid < b.node.osmid;
       }
     );
   }

--- a/src/mjolnir/pbfadminparser.cc
+++ b/src/mjolnir/pbfadminparser.cc
@@ -26,7 +26,7 @@ constexpr uint64_t kMaxOSMNodeId = 4000000000;
 
 // Node equality
 const auto WayNodeEquals = [](const OSMWayNode& a, const OSMWayNode& b) {
-  return a.node_id == b.node_id;
+  return a.node.osmid == b.node.osmid;
 };
 
 struct admin_callback : public OSMPBF::Callback {

--- a/src/mjolnir/pbfadminparser.cc
+++ b/src/mjolnir/pbfadminparser.cc
@@ -72,7 +72,7 @@ struct admin_callback : public OSMPBF::Callback {
     if(current_way_node_index_ < way_nodes_->size()) {
       //update all the nodes that match it
       OSMWayNode way_node;
-      sequence_element<OSMWayNode> element = (*way_nodes_)[current_way_node_index_];
+      sequence<OSMWayNode>::iterator element = (*way_nodes_)[current_way_node_index_];
       while(current_way_node_index_ < way_nodes_->size() && (way_node = element = (*way_nodes_)[current_way_node_index_]).node.osmid == osmid) {
         way_node.node.osmid = osmid;
         way_node.node.lng = static_cast<float>(lng);

--- a/src/mjolnir/pbfgraphbuilder.cc
+++ b/src/mjolnir/pbfgraphbuilder.cc
@@ -108,10 +108,10 @@ int main(int argc, char** argv) {
   if(input_type == "protocolbuffer"){
     // Read the OSM protocol buffer file. Callbacks for nodes, ways, and
     // relations are defined within the PBFParser class
-    auto osm_data = PBFGraphParser::Parse(pt.get_child("mjolnir"), input_files);
+    auto osm_data = PBFGraphParser::Parse(pt.get_child("mjolnir"), input_files, "ways.bin", "way_nodes.bin");
 
     // Build the graph using the OSMNodes and OSMWays from the parser
-    GraphBuilder::Build(pt.get_child("mjolnir"), osm_data);
+    GraphBuilder::Build(pt.get_child("mjolnir"), osm_data, "ways.bin", "way_nodes.bin");
   }/*else if("postgres"){
     //TODO
     if (v.first == "host")

--- a/src/mjolnir/pbfgraphbuilder.cc
+++ b/src/mjolnir/pbfgraphbuilder.cc
@@ -111,8 +111,7 @@ int main(int argc, char** argv) {
     auto osm_data = PBFGraphParser::Parse(pt.get_child("mjolnir"), input_files);
 
     // Build the graph using the OSMNodes and OSMWays from the parser
-    GraphBuilder graphbuilder(pt.get_child("mjolnir"));
-    graphbuilder.Build(osm_data);
+    GraphBuilder::Build(pt.get_child("mjolnir"), osm_data);
   }/*else if("postgres"){
     //TODO
     if (v.first == "host")

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -30,11 +30,6 @@ constexpr uint64_t kMaxOSMNodeId = 4000000000;
 // Absurd classification.
 constexpr uint32_t kAbsurdRoadClass = 777777;
 
-// Node equality
-const auto WayNodeEquals = [](const OSMWayNode& a, const OSMWayNode& b) {
-  return a.node.osmid == b.node.osmid;
-};
-
 // Construct PBFGraphParser based on properties file and input PBF extract
 struct graph_callback : public OSMPBF::Callback {
  public:
@@ -152,7 +147,9 @@ struct graph_callback : public OSMPBF::Callback {
     }
 
     //find a node we need to update
-    current_way_node_index_ = way_nodes_->find_first_of(OSMWayNode{{osmid}}, WayNodeEquals, current_way_node_index_);
+    current_way_node_index_ = way_nodes_->find_first_of(OSMWayNode{{osmid}},
+      [](const OSMWayNode& a, const OSMWayNode& b) { return a.node.osmid == b.node.osmid; },
+      current_way_node_index_);
     //we found the first one
     if(current_way_node_index_ < way_nodes_->size()) {
       //update all the nodes that match it
@@ -735,7 +732,7 @@ OSMData PBFGraphParser::Parse(const boost::property_tree::ptree& pt, const std::
   OSMData osmdata{"ways.bin", "way_node_ref.bin"};
   graph_callback callback(pt, osmdata);
   callback.reset(new sequence<OSMWay>(osmdata.ways_file, true),
-    new sequence<OSMWayNode>(osmdata.way_node_references_file, true));
+    new sequence<OSMWayNode>(osmdata.way_nodes_file, true));
   LOG_INFO("Parsing files: " + boost::algorithm::join(input_files, ", "));
 
   // Parse the ways and find all node Ids needed (those that are part of a
@@ -761,7 +758,7 @@ OSMData PBFGraphParser::Parse(const boost::property_tree::ptree& pt, const std::
   //using much mem, the scoping makes sure to let it go when done sorting
   LOG_INFO("Sorting osm way node references by node id...");
   {
-    sequence<OSMWayNode> way_nodes(osmdata.way_node_references_file, false);
+    sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
     way_nodes.sort(
       [](const OSMWayNode& a, const OSMWayNode& b){
         return a.node.osmid < b.node.osmid;
@@ -777,7 +774,7 @@ OSMData PBFGraphParser::Parse(const boost::property_tree::ptree& pt, const std::
   for (const auto& input_file : input_files) {
     //each time we parse nodes we have to run through the way nodes file from the beginning because
     //because osm node ids are only sorted at the single pbf file level
-    callback.reset(nullptr, new sequence<OSMWayNode>(osmdata.way_node_references_file, false));
+    callback.reset(nullptr, new sequence<OSMWayNode>(osmdata.way_nodes_file, false));
     callback.current_way_node_index_ = callback.last_node_ = callback.last_way_ = callback.last_relation_ = 0;
     OSMPBF::Parser::parse(input_file, OSMPBF::Interest::NODES, callback);
   }
@@ -791,7 +788,7 @@ OSMData PBFGraphParser::Parse(const boost::property_tree::ptree& pt, const std::
   //so we line them first by way index then by shape index of the node
   LOG_INFO("Sorting osm way node references by way index and node shape index...");
   {
-    sequence<OSMWayNode> way_nodes(osmdata.way_node_references_file, false);
+    sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
     way_nodes.sort(
       [](const OSMWayNode& a, const OSMWayNode& b){
         if(a.way_index == b.way_index) {

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -157,7 +157,7 @@ struct graph_callback : public OSMPBF::Callback {
     if(current_way_node_index_ < way_nodes_->size()) {
       //update all the nodes that match it
       OSMWayNode way_node;
-      sequence_element<OSMWayNode> element = (*way_nodes_)[current_way_node_index_];
+      sequence<OSMWayNode>::iterator element = (*way_nodes_)[current_way_node_index_];
       while(current_way_node_index_ < way_nodes_->size() && (way_node = element = (*way_nodes_)[current_way_node_index_]).node.osmid == osmid) {
         way_node.node = n;
         element = way_node;

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -32,7 +32,7 @@ constexpr uint32_t kAbsurdRoadClass = 777777;
 
 // Node equality
 const auto WayNodeEquals = [](const OSMWayNode& a, const OSMWayNode& b) {
-  return a.node_id == b.node_id;
+  return a.node.osmid == b.node.osmid;
 };
 
 // Construct PBFGraphParser based on properties file and input PBF extract
@@ -78,7 +78,7 @@ struct graph_callback : public OSMPBF::Callback {
         && (highway_junction->second == "motorway_junction"));
 
     // Create a new node and set its attributes
-    OSMNode n{static_cast<float>(lng), static_cast<float>(lat)};
+    OSMNode n{osmid, static_cast<float>(lng), static_cast<float>(lat)};
     for (const auto& tag : results) {
 
       if (tag.first == "highway") {
@@ -152,13 +152,13 @@ struct graph_callback : public OSMPBF::Callback {
     }
 
     //find a node we need to update
-    current_way_node_index_ = way_nodes_->find_first_of(OSMWayNode{osmid}, WayNodeEquals, current_way_node_index_);
+    current_way_node_index_ = way_nodes_->find_first_of(OSMWayNode{{osmid}}, WayNodeEquals, current_way_node_index_);
     //we found the first one
     if(current_way_node_index_ < way_nodes_->size()) {
       //update all the nodes that match it
       OSMWayNode way_node;
       sequence_element<OSMWayNode> element = (*way_nodes_)[current_way_node_index_];
-      while(current_way_node_index_ < way_nodes_->size() && (way_node = element = (*way_nodes_)[current_way_node_index_]).node_id == osmid) {
+      while(current_way_node_index_ < way_nodes_->size() && (way_node = element = (*way_nodes_)[current_way_node_index_]).node.osmid == osmid) {
         way_node.node = n;
         element = way_node;
         ++current_way_node_index_;
@@ -203,7 +203,7 @@ struct graph_callback : public OSMPBF::Callback {
       else {
         ++osmdata_.node_count;
       }
-      way_nodes_->push_back({node, ways_->size(), i});
+      way_nodes_->push_back({{node}, ways_->size(), i});
       shape_.set(node);
     }
     intersection_.set(nodes.front());
@@ -764,7 +764,7 @@ OSMData PBFGraphParser::Parse(const boost::property_tree::ptree& pt, const std::
     sequence<OSMWayNode> way_nodes(osmdata.way_node_references_file, false);
     way_nodes.sort(
       [](const OSMWayNode& a, const OSMWayNode& b){
-        return a.node_id < b.node_id;
+        return a.node.osmid < b.node.osmid;
       }
     );
   }

--- a/test/graphbuilder.cc
+++ b/test/graphbuilder.cc
@@ -16,45 +16,14 @@ using namespace valhalla::mjolnir;
 
 namespace {
 
-class test_graph_builder : public GraphBuilder {
- public:
-  using GraphBuilder::GraphBuilder;
-  using GraphBuilder::threads_;
-};
 
-shared_ptr<test_graph_builder> make_builder(boost::optional<unsigned int> threads) {
-  std::stringstream json;
-  if(threads)
-    json << "{\"concurrency\": " << threads << ", \"hierarchy\": {\"tile_dir\": \"/data/valhalla\",\"levels\": [{\"name\": \"local\", \"level\": 2, \"size\": 0.25}]}, \
-              \"tagtransform\": {\"node_script\": \"conf/vertices.lua\", \"node_function\": \"nodes_proc\", \"way_script\": \"conf/edges.lua\", \"way_function\": \"ways_proc\"}}";
-  else
-    json << "{\"hierarchy\": {\"tile_dir\": \"/data/valhalla\",\"levels\": [{\"name\": \"local\", \"level\": 2, \"size\": 0.25}]}, \
-              \"tagtransform\": {\"node_script\": \"conf/vertices.lua\", \"node_function\": \"nodes_proc\", \"way_script\": \"conf/edges.lua\", \"way_function\": \"ways_proc\"}}";
-  boost::property_tree::ptree pt;
-  boost::property_tree::read_json(json, pt);
-  return shared_ptr<test_graph_builder>(new test_graph_builder(pt));
-}
-
-}
-
-void TestThread() {
-
-  if(make_builder(static_cast<unsigned int>(0))->threads_ != 1)
-    throw std::runtime_error("Expected 1 thread but got: " + to_string(make_builder(static_cast<unsigned int>(0))->threads_));
-  for(unsigned int i = 1; i < 5; ++i) {
-    if(make_builder(i)->threads_ != i)
-      throw std::runtime_error("Expected 1 thread but got: " + to_string(make_builder(i)->threads_));
-  }
-  auto system_threads = std::max(static_cast<unsigned int>(1), std::thread::hardware_concurrency());
-  if(make_builder(boost::none)->threads_ != system_threads)
-    throw std::runtime_error("Expected " + to_string(system_threads) +  " thread but got: " + to_string(make_builder(boost::none)->threads_));
 }
 
 int main() {
   test::suite suite("graphbuilder");
 
   // Test setting and getting on random sizes of bit tables
-  suite.test(TEST_CASE(TestThread));
+  //suite.test(TEST_CASE(some_test));
   //TODO: sweet jesus add more tests of this class!
 
   return suite.tear_down();

--- a/test/graphparser.cc
+++ b/test/graphparser.cc
@@ -77,7 +77,7 @@ void BollardsGates(const std::string& config_file) {
   boost::property_tree::json_parser::read_json(config_file, conf);
 
   auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/liechtenstein-latest.osm.pbf"});
-  sequence<OSMWayNode> way_nodes(osmdata.way_node_references_file, false);
+  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
   way_nodes.sort(node_predicate);
 
   //We split set the uses at bollards and gates.
@@ -114,7 +114,7 @@ void RemovableBollards(const std::string& config_file) {
   boost::property_tree::json_parser::read_json(config_file, conf);
 
   auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/rome.osm.pbf"});
-  sequence<OSMWayNode> way_nodes(osmdata.way_node_references_file, false);
+  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
   way_nodes.sort(node_predicate);
 
   //Is a bollard=rising is saved as a gate...with foot flag and bike set.
@@ -129,7 +129,7 @@ void Exits(const std::string& config_file) {
   boost::property_tree::json_parser::read_json(config_file, conf);
 
   auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/harrisburg.osm.pbf"});
-  sequence<OSMWayNode> way_nodes(osmdata.way_node_references_file, false);
+  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
   way_nodes.sort(node_predicate);
 
   auto node = GetNode(33698177, way_nodes);
@@ -195,7 +195,7 @@ void Baltimore(const std::string& config_file) {
     throw std::runtime_error("Forward/Backward/Pedestrian access is not set correctly for way 192573108.");
   }
 
-  sequence<OSMWayNode> way_nodes(osmdata.way_node_references_file, false, true);
+  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false, true);
   way_nodes.sort(node_predicate);
   auto node = GetNode(49473254, way_nodes);
 
@@ -225,7 +225,7 @@ void BicycleTrafficSignals(const std::string& config_file) {
   boost::property_tree::json_parser::read_json(config_file, conf);
 
   auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/nyc.osm.pbf"});
-  sequence<OSMWayNode> way_nodes(osmdata.way_node_references_file, false);
+  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
   way_nodes.sort(node_predicate);
 
   auto node = GetNode(42439096, way_nodes);

--- a/test/graphparser.cc
+++ b/test/graphparser.cc
@@ -76,8 +76,10 @@ void BollardsGates(const std::string& config_file) {
   boost::property_tree::ptree conf;
   boost::property_tree::json_parser::read_json(config_file, conf);
 
-  auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/liechtenstein-latest.osm.pbf"});
-  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
+  std::string ways_file = "test_ways.bin";
+  std::string way_nodes_file = "test_way_nodes.bin";
+  auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/liechtenstein-latest.osm.pbf"}, ways_file, way_nodes_file);
+  sequence<OSMWayNode> way_nodes(way_nodes_file, false);
   way_nodes.sort(node_predicate);
 
   //We split set the uses at bollards and gates.
@@ -113,8 +115,10 @@ void RemovableBollards(const std::string& config_file) {
   boost::property_tree::ptree conf;
   boost::property_tree::json_parser::read_json(config_file, conf);
 
-  auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/rome.osm.pbf"});
-  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
+  std::string ways_file = "test_ways.bin";
+  std::string way_nodes_file = "test_way_nodes.bin";
+  auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/rome.osm.pbf"}, ways_file, way_nodes_file);
+  sequence<OSMWayNode> way_nodes(way_nodes_file, false);
   way_nodes.sort(node_predicate);
 
   //Is a bollard=rising is saved as a gate...with foot flag and bike set.
@@ -128,8 +132,10 @@ void Exits(const std::string& config_file) {
   boost::property_tree::ptree conf;
   boost::property_tree::json_parser::read_json(config_file, conf);
 
-  auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/harrisburg.osm.pbf"});
-  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
+  std::string ways_file = "test_ways.bin";
+  std::string way_nodes_file = "test_way_nodes.bin";
+  auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/harrisburg.osm.pbf"}, ways_file, way_nodes_file);
+  sequence<OSMWayNode> way_nodes(way_nodes_file, false);
   way_nodes.sort(node_predicate);
 
   auto node = GetNode(33698177, way_nodes);
@@ -157,8 +163,10 @@ void Baltimore(const std::string& config_file) {
   boost::property_tree::ptree conf;
   boost::property_tree::json_parser::read_json(config_file, conf);
 
-  auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/baltimore.osm.pbf"});
-  sequence<OSMWay> ways(osmdata.ways_file, false);
+  std::string ways_file = "test_ways.bin";
+  std::string way_nodes_file = "test_way_nodes.bin";
+  auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/baltimore.osm.pbf"}, ways_file, way_nodes_file);
+  sequence<OSMWay> ways(ways_file, false);
   ways.sort(way_predicate);
 
   // bike_forward and reverse is set to false by default.  Meaning defaults for
@@ -195,7 +203,7 @@ void Baltimore(const std::string& config_file) {
     throw std::runtime_error("Forward/Backward/Pedestrian access is not set correctly for way 192573108.");
   }
 
-  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false, true);
+  sequence<OSMWayNode> way_nodes(way_nodes_file, false, true);
   way_nodes.sort(node_predicate);
   auto node = GetNode(49473254, way_nodes);
 
@@ -224,8 +232,10 @@ void BicycleTrafficSignals(const std::string& config_file) {
   boost::property_tree::ptree conf;
   boost::property_tree::json_parser::read_json(config_file, conf);
 
-  auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/nyc.osm.pbf"});
-  sequence<OSMWayNode> way_nodes(osmdata.way_nodes_file, false);
+  std::string ways_file = "test_ways.bin";
+  std::string way_nodes_file = "test_way_nodes.bin";
+  auto osmdata = PBFGraphParser::Parse(conf.get_child("mjolnir"), {"test/data/nyc.osm.pbf"}, ways_file, way_nodes_file);
+  sequence<OSMWayNode> way_nodes(way_nodes_file, false);
   way_nodes.sort(node_predicate);
 
   auto node = GetNode(42439096, way_nodes);

--- a/test/graphparser.cc
+++ b/test/graphparser.cc
@@ -51,11 +51,11 @@ void write_config(const std::string& filename) {
 }
 
 const auto node_predicate = [](const OSMWayNode& a, const OSMWayNode& b) {
-  return a.node_id < b.node_id;
+  return a.node.osmid < b.node.osmid;
 };
 
 OSMNode GetNode(uint64_t node_id, sequence<OSMWayNode>& way_nodes) {
-  OSMWayNode target{node_id};
+  OSMWayNode target{{node_id}};
   if(!way_nodes.find(target, node_predicate))
     throw std::runtime_error("Couldn't find node: " + std::to_string(node_id));
   return target.node;

--- a/test/refs.cc
+++ b/test/refs.cc
@@ -10,17 +10,12 @@ using valhalla::mjolnir::GraphBuilder;
 
 namespace {
 
-class test_graph_builders : public GraphBuilder {
- public:
-  using GraphBuilder::GetRef;
-};
-
 void RefsTest() {
 
   std::string way_refs = "US 21;US 321";
   std::string rel_refs = "US 21|west;US 321|north";
 
-  std::string output = test_graph_builders::GetRef(way_refs,rel_refs);
+  std::string output = GraphBuilder::GetRef(way_refs,rel_refs);
 
   if (output != "US 21 west;US 321 north")
     throw std::runtime_error("US 21 west;US 321 north failed.");
@@ -28,7 +23,7 @@ void RefsTest() {
   way_refs = "I 94;US 21;US 321";
   rel_refs = "US 21|west;US 321|north";
 
-  output = test_graph_builders::GetRef(way_refs,rel_refs);
+  output = GraphBuilder::GetRef(way_refs,rel_refs);
 
   if (output != "I 94;US 21 west;US 321 north")
     throw std::runtime_error("I 94;US 21 west;US 321 north failed.");
@@ -36,7 +31,7 @@ void RefsTest() {
   way_refs = "I 26;US 21;US 321";
   rel_refs = "US 21;US 321";
 
-  output = test_graph_builders::GetRef(way_refs,rel_refs);
+  output = GraphBuilder::GetRef(way_refs,rel_refs);
 
   if (output != "I 26;US 21;US 321")
     throw std::runtime_error("I 26;US 21;US 321 failed.");
@@ -44,7 +39,7 @@ void RefsTest() {
   way_refs = "US 21;I 95;US 321";
   rel_refs = "US 21|north;US 321|south";
 
-  output = test_graph_builders::GetRef(way_refs,rel_refs);
+  output = GraphBuilder::GetRef(way_refs,rel_refs);
 
   if (output != "US 21 north;I 95;US 321 south")
     throw std::runtime_error("US 21 north;I 95;US 321 south failed.");
@@ -52,7 +47,7 @@ void RefsTest() {
   way_refs = "US 21;I 95;US 321";
   rel_refs = "";
 
-  output = test_graph_builders::GetRef(way_refs,rel_refs);
+  output = GraphBuilder::GetRef(way_refs,rel_refs);
 
   if (output != "US 21;I 95;US 321")
    throw std::runtime_error("US 21;I 95;US 321 failed.");
@@ -60,7 +55,7 @@ void RefsTest() {
   way_refs = "US 21;I 95;US 321";
   rel_refs = "I 95|north";
 
-  output = test_graph_builders::GetRef(way_refs,rel_refs);
+  output = GraphBuilder::GetRef(way_refs,rel_refs);
 
   if (output != "US 21;I 95 north;US 321")
    throw std::runtime_error("US 21;I 95 north;US 321 failed.");
@@ -68,7 +63,7 @@ void RefsTest() {
   way_refs = "I 99;US 220;US 322";
   rel_refs = "US 322|west;I 99|south;US 220|south;ADHS O|south";
 
-  output = test_graph_builders::GetRef(way_refs,rel_refs);
+  output = GraphBuilder::GetRef(way_refs,rel_refs);
 
   if (output != "I 99 south;US 220 south;US 322 west")
    throw std::runtime_error("I 99 south;US 220 south;US 322 west failed.");
@@ -76,7 +71,7 @@ void RefsTest() {
   way_refs = "";
   rel_refs = "I 95|north";
 
-  output = test_graph_builders::GetRef(way_refs,rel_refs);
+  output = GraphBuilder::GetRef(way_refs,rel_refs);
 
   if (!output.empty())
    throw std::runtime_error("Empty test failed.");

--- a/test/signinfo.cc
+++ b/test/signinfo.cc
@@ -12,26 +12,18 @@ using valhalla::mjolnir::GraphBuilder;
 
 namespace {
 
-class test_graph_builder : public GraphBuilder {
- public:
-  using GraphBuilder::CreateExitSignInfoList;
-};
-
 void ExitToTest() {
-  GraphId nodeid(1111, 2, 1);
-  Node node;
+  OSMNode node{1234};
   OSMWay way{};
-  std::unordered_map<GraphId, std::string> map_ref;
-  std::unordered_map<GraphId, std::string> map_name;
-  std::unordered_map<GraphId, std::string> map_exit_to;
   OSMData osmdata{};
 
   node.set_exit_to(true);
 
-  map_exit_to[nodeid] = "US 11;To I 81;Carlisle;Harrisburg";
+
+  osmdata.node_exit_to[node.osmid] = "US 11;To I 81;Carlisle;Harrisburg";
 
   std::vector<SignInfo> exitsigns;
-  exitsigns = test_graph_builder::CreateExitSignInfoList(nodeid, node, way, osmdata, map_ref, map_exit_to, map_name);
+  exitsigns = GraphBuilder::CreateExitSignInfoList(node, way, osmdata);
 
   if (exitsigns.size() == 4) {
     for (auto& exitsign : exitsigns) {
@@ -46,9 +38,9 @@ void ExitToTest() {
   else throw std::runtime_error("US 11/To I 81/Carlisle/Harrisburg failed to be parsed.  " + exitsigns.size() );
 
   exitsigns.clear();
-  map_exit_to[nodeid] = "US 11;Toward I 81;Carlisle;Harrisburg";
+  osmdata.node_exit_to[node.osmid] = "US 11;Toward I 81;Carlisle;Harrisburg";
 
-  exitsigns = test_graph_builder::CreateExitSignInfoList(nodeid, node, way, osmdata, map_ref, map_exit_to, map_name);
+  exitsigns = GraphBuilder::CreateExitSignInfoList(node, way, osmdata);
 
   if (exitsigns.size() == 4) {
     for (auto& exitsign : exitsigns) {
@@ -62,9 +54,9 @@ void ExitToTest() {
   else throw std::runtime_error("US 11;Toward I 81;Carlisle;Harrisburg failed to be parsed.");
 
   exitsigns.clear();
-  map_exit_to[nodeid] = "I 95 To I 695";
+  osmdata.node_exit_to[node.osmid] = "I 95 To I 695";
 
-  exitsigns = test_graph_builder::CreateExitSignInfoList(nodeid, node, way, osmdata, map_ref, map_exit_to, map_name);
+  exitsigns = GraphBuilder::CreateExitSignInfoList(node, way, osmdata);
 
   if (exitsigns.size() == 2) {
      if (exitsigns[0].type() != Sign::Type::kExitBranch)
@@ -79,9 +71,9 @@ void ExitToTest() {
   else throw std::runtime_error("I 95 To I 695 failed to be parsed.");
 
   exitsigns.clear();
-  map_exit_to[nodeid] = "I 495 Toward I 270";
+  osmdata.node_exit_to[node.osmid] = "I 495 Toward I 270";
 
-  exitsigns = test_graph_builder::CreateExitSignInfoList(nodeid, node, way, osmdata, map_ref, map_exit_to, map_name);
+  exitsigns = GraphBuilder::CreateExitSignInfoList(node, way, osmdata);
 
   if (exitsigns.size() == 2) {
     if (exitsigns[0].type() != Sign::Type::kExitBranch)
@@ -96,9 +88,9 @@ void ExitToTest() {
   else throw std::runtime_error("I 495 Toward I 270 failed to be parsed.");
 
   exitsigns.clear();
-  map_exit_to[nodeid] = "I 495 Toward I 270 To I 95";//default to toward.  Punt on parsing.
+  osmdata.node_exit_to[node.osmid] = "I 495 Toward I 270 To I 95";//default to toward.  Punt on parsing.
 
-  exitsigns = test_graph_builder::CreateExitSignInfoList(nodeid, node, way, osmdata, map_ref, map_exit_to, map_name);
+  exitsigns = GraphBuilder::CreateExitSignInfoList(node, way, osmdata);
 
   if (exitsigns.size() == 1) {
     if (exitsigns[0].type() != Sign::Type::kExitToward)

--- a/valhalla/mjolnir/directededgebuilder.h
+++ b/valhalla/mjolnir/directededgebuilder.h
@@ -443,6 +443,11 @@ class DirectedEdgeBuilder : public baldr::DirectedEdge {
    */
   void set_edge_to_right(const uint32_t localidx, const bool right);
 
+  /**
+   * Creates the opposite orientation of the directed edge
+   */
+  DirectedEdgeBuilder flipped() const;
+
 };
 
 }

--- a/valhalla/mjolnir/graphbuilder.h
+++ b/valhalla/mjolnir/graphbuilder.h
@@ -35,10 +35,13 @@ class GraphBuilder {
   /**
    * Tell the builder to build the tiles from the provided datasource
    * and configs
-   * @param  config
-   * @param  osmdata  OSM data used to build the graph.
+   * @param  config         properties file
+   * @param  osmdata        OSM data used to build the graph.
+   * @param  ways_file      where to store the ways so they arent in memory
+   * @param  way_nodes_file where to store the nodes so they arent in memory
    */
-  static void Build(const boost::property_tree::ptree& pt, OSMData& osmdata);
+  static void Build(const boost::property_tree::ptree& pt, OSMData& osmdata,
+      const std::string& ways_file, const std::string& way_nodes_file);
 
   static std::string GetRef(const std::string& way_ref, const std::string& relation_ref);
 

--- a/valhalla/mjolnir/graphbuilder.h
+++ b/valhalla/mjolnir/graphbuilder.h
@@ -259,8 +259,7 @@ class GraphBuilder {
    * Add a new node to the tile (based on the OSM node lat,lng). Return
    * the GraphId of the node.
    */
-  GraphId AddNodeToTile(const uint64_t osmnodeid, const OSMNode& osmnode,
-                        const uint32_t edgeindex, const bool link);
+  GraphId AddNodeToTile(const OSMNode& osmnode, const uint32_t edgeindex, const bool link);
 
   /**
    * Get a reference to a node given its graph Id.

--- a/valhalla/mjolnir/graphbuilder.h
+++ b/valhalla/mjolnir/graphbuilder.h
@@ -40,6 +40,10 @@ class GraphBuilder {
    */
   static void Build(const boost::property_tree::ptree& pt, OSMData& osmdata);
 
+  static std::string GetRef(const std::string& way_ref, const std::string& relation_ref);
+
+  static std::vector<SignInfo> CreateExitSignInfoList(const OSMNode& node, const OSMWay& way, const OSMData& osmdata);
+
 };
 
 }

--- a/valhalla/mjolnir/osmdata.h
+++ b/valhalla/mjolnir/osmdata.h
@@ -44,7 +44,7 @@ struct OSMData {
   // Stores all the ways that are part of the road network
   std::string ways_file;
   // Node references, contain the actual nodes associated to ways
-  std::string way_node_references_file;
+  std::string way_nodes_file;
 
   size_t osm_node_count;        // Count of osm nodes
   size_t osm_way_count;         // Count of osm ways

--- a/valhalla/mjolnir/osmdata.h
+++ b/valhalla/mjolnir/osmdata.h
@@ -40,12 +40,6 @@ struct OSMWayNode {
  * Populated by the PBF parser and sent into GraphBuilder.
  */
 struct OSMData {
-
-  // Stores all the ways that are part of the road network
-  std::string ways_file;
-  // Node references, contain the actual nodes associated to ways
-  std::string way_nodes_file;
-
   size_t osm_node_count;        // Count of osm nodes
   size_t osm_way_count;         // Count of osm ways
   size_t osm_way_node_count;    // Count of osm nodes on osm ways

--- a/valhalla/mjolnir/osmdata.h
+++ b/valhalla/mjolnir/osmdata.h
@@ -26,10 +26,9 @@ enum class OSMType : uint8_t {
  };
 
 struct OSMWayNode {
-  uint64_t node_id;
+  OSMNode node;
   size_t way_index;
   size_t way_shape_node_index;
-  OSMNode node;
 };
 
 /**

--- a/valhalla/mjolnir/osmnode.h
+++ b/valhalla/mjolnir/osmnode.h
@@ -30,6 +30,15 @@ struct NodeAttributes {
  */
 struct OSMNode {
 
+  // The osm id of the node
+  uint64_t osmid;
+
+  // Lat,lng of the node
+  float lng, lat;
+
+  // Node attributes. Shared by OSMNode and GraphBuilder Node.
+  NodeAttributes attributes_;
+
   /**
    * Sets the lat,lng.
    * @param  ll  Lat,lng of the node.
@@ -153,12 +162,6 @@ struct OSMNode {
    * @return  Returns the attributes.
    */
   const NodeAttributes& attributes() const;
-
-  // Lat,lng of the node
-  float lng, lat;
-
-  // Node attributes. Shared by OSMNode and GraphBuilder Node.
-  NodeAttributes attributes_;
 };
 
 }

--- a/valhalla/mjolnir/pbfgraphparser.h
+++ b/valhalla/mjolnir/pbfgraphparser.h
@@ -18,8 +18,13 @@ class PBFGraphParser {
 
   /**
    * Loads given input files
+   * @param  pt             properties file
+   * @param  input_files    the protobuf files to parse
+   * @param  ways_file      where to store the ways so they arent in memory
+   * @param  way_nodes_file where to store the nodes so they arent in memory
    */
-  static OSMData Parse(const boost::property_tree::ptree& pt, const std::vector<std::string>& input_files);
+  static OSMData Parse(const boost::property_tree::ptree& pt, const std::vector<std::string>& input_files,
+      const std::string& ways_file, const std::string& way_nodes_file);
 
 };
 

--- a/valhalla/mjolnir/sequence.h
+++ b/valhalla/mjolnir/sequence.h
@@ -22,7 +22,7 @@ namespace valhalla{
 namespace mjolnir{
 
 template <class T>
-struct sequence {
+class sequence {
  public:
   //static_assert(std::is_pod<T>::value, "sequence requires POD types for now");
   static const size_t npos = -1;
@@ -228,7 +228,7 @@ struct sequence {
     flush();
     //grab each element and do something with it
     for(size_t i = 0; i < element_count; ++i)
-      predicate(*at(i));
+      predicate(*(at(i)));
   }
 
   //force writing whatever we have in the write_buffer to file
@@ -272,7 +272,7 @@ struct sequence {
     }
     operator T() {
       if(parent->mmap_handle)
-        return *(static_cast<const T*>(parent->mmap_handle) + index);
+        return *(static_cast<T*>(parent->mmap_handle) + index);
 
       T result;
       parent->file->seekg(index * sizeof(T));
@@ -339,7 +339,7 @@ struct sequence {
       return index;
     }
    protected:
-    iterator(sequence* parent, size_t offset): parent(parent), index(index) {}
+    iterator(sequence* base, size_t offset): parent(base), index(offset) {}
     sequence* parent;
     size_t index;
   };

--- a/valhalla/mjolnir/sequence.h
+++ b/valhalla/mjolnir/sequence.h
@@ -262,7 +262,7 @@ struct sequence {
     }
     iterator& operator=(const T& other) {
       if(parent->mmap_handle) {
-        (static_cast<T*>(parent->mmap_handle) + index) = other;
+        *(static_cast<T*>(parent->mmap_handle) + index) = other;
         return *this;
       }
 
@@ -328,6 +328,9 @@ struct sequence {
     }
     bool operator==(const iterator& other) const {
       return parent == other.parent && index == other.index;
+    }
+    bool operator!=(const iterator& other) const {
+      return index != other.index || parent != other.parent;
     }
     size_t operator-(const iterator& other) const {
       return index - other.index;


### PR DESCRIPTION
this lets us safe s-tons of memory. a this point the only thing in memory of any weight is the street name map. this does use memory maps for everything though so the os will pretty much let you access the file as if it were memory up to the point of running out of memory but just not, which is what we want.

when writing this we realized that we werent adding a second directed edge for loops. i have put code in place to do this but i have it commented out because its not working quite right.

on the pa import the whole thing still takes only 2 minutes which is great because it basically doesnt increase the import time at all.

I guess i should say how it works!

When constructing edges we put the start and end graph node of a given graph edge to file (so the nodes at intersections are duplicated). Each node stores a reference to the edge from which it was born (and whether it was the beginning of the edge or end). We then sort the graph nodes first by graphid (what tile they are in) and then by osmid so we have all of the duplicate nodes next to eachother, like this (these are osmids of nodes):

3,3,3,3,7,7,7,9,25,25

Then when we ware writing tiles we simply scan seqentially through the file, node 3 has 4 edges connected to it, node 7 has 3 edges, node 9 is a dead end, node 25 might be a gate. For any given import we now have 4 files we memory map:

ways.bin - with just wayid and attribution per way
way_nodes.bin - with each node and its id and attribution as shape points of the way in the order they occur in the way (duplicates where ways intersect)
edges.bin - the ways broken up into graph edges where the ways intersect
nodes.bin - the start and end node of each graph edge, does encapsulate the way_node and references to the graph edge in the edges file

For the PA import (pbf is only 106M) we end up with:
kkreiser@klaptop:~/sandbox/valhalla/mjolnir$ ls -hal *.bin
-rw-r--r-- 1 kkreiser kkreiser  27M Mar 12 09:14 edges.bin
-rw-r--r-- 1 kkreiser kkreiser  76M Mar 12 09:14 nodes.bin
-rw-r--r-- 1 kkreiser kkreiser 290M Mar 12 09:14 way_node_ref.bin
-rw-r--r-- 1 kkreiser kkreiser  47M Mar 12 09:14 ways.bin

So we slightly more than quadrupale the original import size.. This would mean that for a planet import we'll need about 28G * 4.15 = 116G