### PR TITLE
route tiles for the whole the planet!!!!

### DIFF
--- a/src/mjolnir/graphoptimizer.cc
+++ b/src/mjolnir/graphoptimizer.cc
@@ -1,9 +1,23 @@
 #include "mjolnir/graphoptimizer.h"
-#include <valhalla/midgard/logging.h>
+#include "valhalla/mjolnir/graphtilebuilder.h"
 
 #include <ostream>
 #include <set>
 #include <boost/format.hpp>
+#include <sstream>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
+#include <utility>
+
+#include <valhalla/midgard/logging.h>
+#include <valhalla/midgard/pointll.h>
+#include <valhalla/baldr/tilehierarchy.h>
+#include <valhalla/baldr/graphid.h>
+#include <valhalla/baldr/graphconstants.h>
+#include <valhalla/baldr/graphreader.h>
+
 
 using namespace valhalla::midgard;
 using namespace valhalla::baldr;
@@ -130,6 +144,10 @@ void GraphOptimizer::Optimize(const boost::property_tree::ptree& pt) {
       if (tilebuilder.size() == 0) {
         continue;
       }
+
+      // Check if we need to clear the tile cache
+      if(graphreader_.OverCommitted())
+        graphreader_.Clear();
 
       // Copy existing header. No need to update any counts or offsets.
       GraphTileHeader existinghdr = *(tilebuilder.header());

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -1,5 +1,22 @@
 #include "mjolnir/hierarchybuilder.h"
+#include "valhalla/mjolnir/graphtilebuilder.h"
+
+#include <sstream>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
+#include <utility>
+#include <boost/property_tree/ptree.hpp>
+
+#include <valhalla/midgard/pointll.h>
+#include <valhalla/baldr/tilehierarchy.h>
+#include <valhalla/baldr/graphid.h>
+#include <valhalla/baldr/graphconstants.h>
+#include <valhalla/baldr/graphtile.h>
+#include <valhalla/baldr/graphreader.h>
 #include <valhalla/midgard/logging.h>
+
 #include <boost/format.hpp>
 
 #include <ostream>
@@ -10,6 +27,40 @@ using namespace valhalla::baldr;
 using namespace valhalla::mjolnir;
 
 namespace {
+
+// Simple structure to describe a connection between 2 levels
+struct NodeConnection {
+  GraphId basenode;
+  GraphId newnode;
+
+  NodeConnection(const GraphId& bn, const GraphId& nn)
+      : basenode(bn),
+        newnode(nn) {
+  }
+
+  // For sorting by Id
+  bool operator < (const NodeConnection& other) const {
+    return basenode.id() < other.basenode.id();
+  }
+};
+
+// Simple structure representing nodes in the new level
+struct NewNode {
+  GraphId basenode;
+  bool contract;
+
+  NewNode(const GraphId& bn, const bool c)
+      : basenode(bn),
+        contract(c) {
+  }
+};
+
+// Simple structure to hold the 2 pair of directed edges at a node.
+// First edge in the pair is incoming and second is outgoing
+struct EdgePairs {
+  std::pair<GraphId, GraphId> edge1;
+  std::pair<GraphId, GraphId> edge2;
+};
 
 struct hierarchy_info {
   uint32_t contractcount_;
@@ -405,6 +456,10 @@ void FormTilesInNewLevel(
       continue;
     }
 
+    // Check if we need to clear the tile cache
+    if(info.graphreader_.OverCommitted())
+      info.graphreader_.Clear();
+
     // Create GraphTileBuilder for the new tile
     GraphTileBuilder tilebuilder;
 
@@ -662,6 +717,10 @@ void ConnectBaseLevelToNewLevel(
       }
     }
 
+    // Check if we need to clear the tile cache
+    if(info.graphreader_.OverCommitted())
+      info.graphreader_.Clear();
+
     // Increment tile Id
     tileid++;
   }
@@ -677,6 +736,10 @@ void GetNodesInNewLevel(
   uint32_t baselevel = (uint32_t) base_level.level;
   const GraphTile* tile = nullptr;
   for (uint32_t basetileid = 0; basetileid < ntiles; basetileid++) {
+    // Check if we need to clear the tile cache
+    if(info.graphreader_.OverCommitted())
+      info.graphreader_.Clear();
+
     // Get the graph tile. Skip if no tile exists (common case)
     tile = info.graphreader_.GetGraphTile(GraphId(basetileid, baselevel, 0));
     if (tile == nullptr) {

--- a/valhalla/mjolnir/graphoptimizer.h
+++ b/valhalla/mjolnir/graphoptimizer.h
@@ -1,20 +1,7 @@
 #ifndef VALHALLA_MJOLNIR_GRAPHOPTIMIZER_H
 #define VALHALLA_MJOLNIR_GRAPHOPTIMIZER_H
 
-#include <sstream>
-#include <iostream>
-#include <string>
-#include <vector>
-#include <map>
-#include <utility>
 #include <boost/property_tree/ptree.hpp>
-
-#include <valhalla/midgard/pointll.h>
-#include <valhalla/baldr/tilehierarchy.h>
-#include <valhalla/baldr/graphid.h>
-#include <valhalla/baldr/graphconstants.h>
-#include <valhalla/baldr/graphreader.h>
-#include <valhalla/mjolnir/graphtilebuilder.h>
 
 namespace valhalla {
 namespace mjolnir {

--- a/valhalla/mjolnir/hierarchybuilder.h
+++ b/valhalla/mjolnir/hierarchybuilder.h
@@ -1,58 +1,10 @@
 #ifndef VALHALLA_MJOLNIR_HIERARCHYBUILDER_H
 #define VALHALLA_MJOLNIR_HIERARCHYBUILDER_H
 
-#include <sstream>
-#include <iostream>
-#include <string>
-#include <vector>
-#include <map>
-#include <utility>
 #include <boost/property_tree/ptree.hpp>
-
-#include <valhalla/midgard/pointll.h>
-#include <valhalla/baldr/tilehierarchy.h>
-#include <valhalla/baldr/graphid.h>
-#include <valhalla/baldr/graphconstants.h>
-#include <valhalla/baldr/graphtile.h>
-#include <valhalla/baldr/graphreader.h>
-#include <valhalla/mjolnir/graphtilebuilder.h>
 
 namespace valhalla {
 namespace mjolnir {
-
-// Simple structure to describe a connection between 2 levels
-struct NodeConnection {
-  baldr::GraphId basenode;
-  baldr::GraphId newnode;
-
-  NodeConnection(const baldr::GraphId& bn, const baldr::GraphId& nn)
-      : basenode(bn),
-        newnode(nn) {
-  }
-
-  // For sorting by Id
-  bool operator < (const NodeConnection& other) const {
-    return basenode.id() < other.basenode.id();
-  }
-};
-
-// Simple structure representing nodes in the new level
-struct NewNode {
-  baldr::GraphId basenode;
-  bool contract;
-
-  NewNode(const baldr::GraphId& bn, const bool c)
-      : basenode(bn),
-        contract(c) {
-  }
-};
-
-// Simple structure to hold the 2 pair of directed edges at a node.
-// First edge in the pair is incoming and second is outgoing
-struct EdgePairs {
-  std::pair<GraphId, GraphId> edge1;
-  std::pair<GraphId, GraphId> edge2;
-};
 
 /**
  * Class used to construct temporary data used to build the initial graph.

--- a/valhalla/mjolnir/sequence.h
+++ b/valhalla/mjolnir/sequence.h
@@ -1,11 +1,6 @@
 #ifndef VALHALLA_MJOLNIR_SEQUENCE_H_
 #define VALHALLA_MJOLNIR_SEQUENCE_H_
 
-/*
-g++ sequence.cpp -o sequence -std=c++11 -O2
-./sequence 100000000
-*/
-
 #include <fstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
This enables cache size control during the later stages of tile refinement in which it is presumed that we are running out of memory because we currently have an infinite cache limit. This sets a limit by default (1 gig) and checks periodically if we are over that limit and just purges the whole cache. Later on we will need to be smarter about this, but that will happen when we put the cache api behind a service as well anyway so this should be ok for now.