### PR TITLE
Add ctry crossing flag and update edge sorting

### DIFF
--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -282,6 +282,11 @@ void DirectedEdgeBuilder::set_speed_type(const SpeedType speed_type) {
   attributes_.speed_type = static_cast<uint8_t>(speed_type);
 }
 
+// Set the country crossing flag.
+void DirectedEdgeBuilder::set_ctry_crossing(const bool crossing) {
+  attributes_.ctry_crossing = crossing;
+}
+
 // Set all forward access modes to true (used for transition edges)
 void DirectedEdgeBuilder::set_all_forward_access() {
   forwardaccess_.v = kAllAccess;

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -54,7 +54,10 @@ struct Edge {
     uint32_t backward_signal  : 1;
     uint32_t link             : 1;
     uint32_t reclass_link     : 1;
-    uint32_t spare            : 6;
+    uint32_t has_names        : 1;
+    uint32_t driveforward     : 1;   // For sorting in collect_node_edges
+                                     //  - set based on source node
+    uint32_t spare            : 4;
   };
   EdgeAttributes attributes;
 
@@ -86,12 +89,19 @@ struct Edge {
     }
     e.attributes.link = way.link();
     e.attributes.reclass_link = false;
+    e.attributes.has_names = (way.name_index_ != 0
+                           || way.name_en_index_ != 0
+                           || way.alt_name_index_ != 0
+                           || way.official_name_index_ != 0
+                           || way.ref_index_ != 0
+                           || way.int_ref_index_ != 0);
     return e;
   }
 
   /**
-   * For sorting edges. By importance, driveability
-   * (TODO - presence of name, end of simple restriction)
+   * For sorting edges. By driveability (forward), importance, and
+   * presence of names.
+   * (TODO - end of simple restriction?)
    */
   bool operator < (const Edge& other) const {
     // Is this a loop?
@@ -100,18 +110,23 @@ struct Edge {
         sourcenode_ == targetnode_) {
       false;
     }
-    if (attributes.importance == other.attributes.importance) {
-      // Equal importance - check driveability
-      bool d  = attributes.driveableforward || attributes.driveablereverse;
-      bool od = other.attributes.driveableforward || other.attributes.driveablereverse;
-      if (d == od) {
-        // Tiebreaker
-        return llindex_ < other.llindex_;
+
+    // Sort by driveability (forward, importance, has_names)
+    bool d  = attributes.driveforward;
+    bool od = other.attributes.driveforward;
+    if (d == od) {
+      if (attributes.importance == other.attributes.importance) {
+        // Equal importance - check presence of names
+        if (attributes.has_names == other.attributes.has_names) {
+          return llindex_ < other.llindex_;
+        } else {
+          return attributes.has_names > other.attributes.has_names;
+        }
       } else {
-        return d > od;
+        return attributes.importance < other.attributes.importance;
       }
     } else {
-      return attributes.importance < other.attributes.importance;
+      return d > od;
     }
   }
 };
@@ -157,6 +172,8 @@ node_bundle collect_node_edges(const sequence<Node>::iterator& node_itr, sequenc
     if(node.is_start()) {
       auto edge_itr = edges[node.start_of];
       auto edge = *edge_itr;
+      // Set driveforward - this edge is traversed in forward direction
+      edge.attributes.driveforward = edge.attributes.driveableforward;
       bundle.node_edges.emplace(std::make_pair(edge, node.start_of));
       bundle.node.attributes_.link_edge = bundle.node.attributes_.link_edge || edge.attributes.link;
       // Do not count non-driveable (e.g. emergency service roads) as a non-link edge
@@ -170,6 +187,8 @@ node_bundle collect_node_edges(const sequence<Node>::iterator& node_itr, sequenc
     if(node.is_end()) {
       auto edge_itr = edges[node.end_of];
       auto edge = *edge_itr;
+      // Set driveforward - this edge is traversed in reverse direction
+      edge.attributes.driveforward = edge.attributes.driveablereverse;
       bundle.node_edges.emplace(std::make_pair(edge, node.end_of));
       bundle.node.attributes_.link_edge = bundle.node.attributes_.link_edge || edge.attributes.link;
       // Do not count non-driveable (e.g. emergency service roads) as a non-link edge

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -865,6 +865,10 @@ void enhance(const boost::property_tree::ptree& pt, GraphReader& reader, IdTable
           stats.internalcount++;
         }
 
+        // Set country crossing flag
+        if (false)  // TODO
+          directededge.set_ctry_crossing(true);
+
         // Add the directed edge
         directededges.emplace_back(std::move(directededge));
       }

--- a/valhalla/mjolnir/directededgebuilder.h
+++ b/valhalla/mjolnir/directededgebuilder.h
@@ -244,9 +244,15 @@ class DirectedEdgeBuilder : public baldr::DirectedEdge {
 
   /**
    * Set the speed type (see graphconstants.h)
-   * @param  speed_type  Returns the speed type.
+   * @param  speed_type  Speed type.
    */
   void set_speed_type(const SpeedType speed_type);
+
+  /**
+   * Set the country crossing flag.
+   * @param  crossing  True if this edge crosses into a new country.
+   */
+  void set_ctry_crossing(const bool crossing);
 
   /**
    * Set all forward access modes to true (used for transition edges)


### PR DESCRIPTION
Edges from a node are sorted by: 1) driveability from the node, 2) importance, 3) presence of names.
Ctry crossing flag added but not set yet (placeholder in graphenhancer for when admin logic is more complete).