### PR TITLE
Admin fix to use state name in addition to country ISO

### DIFF
--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -522,7 +522,7 @@ uint32_t GraphTileBuilder::AddAdmin(const std::string& country_name, const std::
                                     const std::string& country_iso, const std::string& state_iso,
                                     const std::string& start_dst, const std::string& end_dst) {
 
-  auto existing_admin_info_offset_item = admin_info_offset_map.find(country_iso);
+  auto existing_admin_info_offset_item = admin_info_offset_map.find(country_iso+state_name);
   if (existing_admin_info_offset_item == admin_info_offset_map.end()) {
 
     uint32_t country_offset = 0;
@@ -582,7 +582,7 @@ uint32_t GraphTileBuilder::AddAdmin(const std::string& country_name, const std::
                                  start_dst, end_dst);
 
     // Add to the map
-    admin_info_offset_map.emplace(country_iso, admins_builder_.size()-1);
+    admin_info_offset_map.emplace(country_iso+state_name, admins_builder_.size()-1);
 
     return admins_builder_.size()-1;
 

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -38,7 +38,7 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode, DirectedEdge& edge,
   const NodeInfo* nodeinfo = tile->node(endnode.id());
 
   // Set the end node iso.  Used for country crossings.
-  endnodeiso_ = tile->admin(nodeinfo->admin_index()).country_iso();
+  endnodeiso_ = tile->admin(nodeinfo->admin_index())->country_iso();
 
   // TODO - check if more than 1 edge has matching startnode and
   // distance!
@@ -177,7 +177,7 @@ void GraphValidator::Validate(const boost::property_tree::ptree& pt) {
         NodeInfoBuilder nodeinfo = tilebuilder.node(i);
 
         const GraphTile* tile = graphreader_.GetGraphTile(node);
-        std::string begin_node_iso = tile->admin(nodeinfo.admin_index()).country_iso();
+        std::string begin_node_iso = tile->admin(nodeinfo.admin_index())->country_iso();
 
         // Go through directed edges and update data
         for (uint32_t j = 0, n = nodeinfo.edge_count(); j < n; j++) {


### PR DESCRIPTION
Also look for cases where only one admin poly covers a tile.