### PR TITLE
GraphEnhancer updates - clear cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,9 @@ libtool
 # built objects
 valhalla/proto
 src/proto
+adminbenchmark
 pbfgraphbuilder
 pbfadminbuilder
-hierarchybuilder
 *.o
 .deps/
 .dirstamp

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -1,5 +1,4 @@
 #include "mjolnir/graphenhancer.h"
-#include "mjolnir/idtable.h"
 #include "mjolnir/graphtilebuilder.h"
 
 #include <memory>
@@ -8,6 +7,7 @@
 #include <mutex>
 #include <vector>
 #include <list>
+#include <queue>
 #include <unordered_set>
 #include <unordered_map>
 #include <cinttypes>
@@ -42,10 +42,9 @@ using namespace valhalla::midgard;
 using namespace valhalla::baldr;
 using namespace valhalla::mjolnir;
 
-
 namespace {
 
-
+// Geometry types for admin queries
 typedef boost::geometry::model::d2::point_xy<double> point_type;
 typedef boost::geometry::model::polygon<point_type> polygon_type;
 typedef boost::geometry::model::multi_polygon<polygon_type> multi_polygon_type;
@@ -185,7 +184,7 @@ bool IsUnreachable(GraphReader& reader, std::mutex& lock,
   std::unordered_set<GraphId> expandset;   // Set of nodes to expand
   expandset.insert(directededge.endnode());
 
-  // Expand until we either find a secondary or higher classification,
+  // Expand until we either find a tertiary or higher classification,
   // expand more than kUnreachableIterations nodes, or cannot expand
   // any further.
   uint32_t n = 0;
@@ -270,18 +269,15 @@ bool IsNotThruEdge(GraphReader& reader, std::mutex& lock,
   return false;
 }
 
+// Test if the edge is internal to an intersection.
 bool IsIntersectionInternal(GraphReader& reader, std::mutex& lock,
                             const GraphId& startnode,
                             NodeInfoBuilder& startnodeinfo,
                             DirectedEdgeBuilder& directededge,
                             const uint32_t idx) {
-  // Internal intersection edges must be short
-  if (directededge.length() > kMaxInternalLength) {
-    return false;
-  }
-
-  // Internal intersection edges must not be a roundabout
-  if (directededge.roundabout()) {
+  // Internal intersection edges must be short and cannot be a roundabout
+  if (directededge.length() > kMaxInternalLength ||
+      directededge.roundabout()) {
     return false;
   }
 
@@ -465,7 +461,7 @@ std::unordered_map<uint32_t,multi_polygon_type> GetAdminInfo(sqlite3 *db_handle,
 
   sqlite3_stmt *stmt = 0;
   uint32_t ret;
-  char *err_msg = NULL;
+  char *err_msg = nullptr;
   uint32_t result = 0;
   uint32_t id = 0;
   bool dor = true;
@@ -703,37 +699,34 @@ bool ConsistentNames(const std::string& country_code,
 }
 
 // We make sure to lock on reading and writing because we dont want to race
-// since difference threads, use for the done map as well
-void enhance(const boost::property_tree::ptree& pt, GraphReader& reader, IdTable& done_set, std::mutex& lock, std::promise<enhancer_stats>& result) {
-
+// since difference threads, use for the tilequeue as well
+void enhance(const boost::property_tree::ptree& pt,
+             boost::property_tree::ptree& hierarchy_properties,
+             std::queue<GraphId>& tilequeue, std::mutex& lock,
+             std::promise<enhancer_stats>& result) {
+  // Initialize the admin DB (if it exists)
   std::string dir = pt.get<std::string>("admin_dir");
   std::string db_name = pt.get<std::string>("db_name");
-
   std::string database = dir + "/" +  db_name;
-
   sqlite3 *db_handle = nullptr;
-
   if (boost::filesystem::exists(database)) {
-
     spatialite_init(0);
-
-    sqlite3_stmt *stmt = 0;
-    uint32_t ret;
-    char *err_msg = NULL;
+    sqlite3_stmt* stmt = 0;
+    char* err_msg = nullptr;
     std::string sql;
-
-    ret = sqlite3_open_v2(database.c_str(), &db_handle, SQLITE_OPEN_READONLY, NULL);
+    uint32_t ret = sqlite3_open_v2(database.c_str(), &db_handle,
+                        SQLITE_OPEN_READONLY, nullptr);
     if (ret != SQLITE_OK) {
       LOG_ERROR("cannot open " + database);
       sqlite3_close(db_handle);
-      db_handle = NULL;
+      db_handle = nullptr;
       return;
     }
 
     // loading SpatiaLite as an extension
     sqlite3_enable_load_extension(db_handle, 1);
     sql = "SELECT load_extension('libspatialite.so')";
-    ret = sqlite3_exec(db_handle, sql.c_str(), NULL, NULL, &err_msg);
+    ret = sqlite3_exec(db_handle, sql.c_str(), nullptr, nullptr, &err_msg);
     if (ret != SQLITE_OK) {
       LOG_ERROR("load_extension() error: " + std::string(err_msg));
       sqlite3_free(err_msg);
@@ -746,9 +739,8 @@ void enhance(const boost::property_tree::ptree& pt, GraphReader& reader, IdTable
   else
     LOG_INFO("Admin db " + database + " not found.  Not saving admin information.");
 
-
-  std::unordered_map<uint32_t,multi_polygon_type> polys;
-  std::unordered_map<uint32_t,bool> drive_on_right;
+  // Local Graphreader
+  GraphReader reader(hierarchy_properties);
 
   // Get some things we need throughout
   enhancer_stats stats{std::numeric_limits<float>::min(), 0};
@@ -758,25 +750,20 @@ void enhance(const boost::property_tree::ptree& pt, GraphReader& reader, IdTable
   auto tiles = tile_hierarchy.levels().rbegin()->second.tiles;
   lock.unlock();
 
-  // Iterate through the tiles and perform enhancements
-  for (uint32_t id = 0; id < tiles.TileCount(); id++) {
-    GraphId tile_id(id, local_level, 0);
-
-    // If no tile exists skip it
-    if(!GraphReader::DoesTileExist(tile_hierarchy, tile_id))
-      continue;
-
-    // If someone else is working/worked on this tile we can skip it
+  // Iterate through the tiles in the queue and perform enhancements
+  std::unordered_map<uint32_t,multi_polygon_type> polys;
+  std::unordered_map<uint32_t,bool> drive_on_right;
+  while (true) {
+    // Get the next tile Id from the queue and get writeable
+    // and readable tile
     lock.lock();
-    if(done_set.IsUsed(id)) {
+    if (tilequeue.empty()) {
       lock.unlock();
-      continue;
+      break;
     }
-    done_set.set(id);
-    lock.unlock();
-
-    // Get writeable and readable tiles
-    lock.lock();
+    GraphId tile_id = tilequeue.front();
+    uint32_t id  = tile_id.tileid();
+    tilequeue.pop();
     GraphTileBuilder tilebuilder(tile_hierarchy, tile_id);
     const GraphTile* tile = reader.GetGraphTile(tile_id);
     lock.unlock();
@@ -802,11 +789,8 @@ void enhance(const boost::property_tree::ptree& pt, GraphReader& reader, IdTable
     std::vector<DirectedEdgeBuilder> directededges;
 
     // Iterate through the nodes
-    float localdensity = 0.0f;
-    uint32_t nodecount = tilebuilder.header()->nodecount();
     const GraphTile* endnodetile = nullptr;
-
-    for (uint32_t i = 0; i < nodecount; i++) {
+    for (uint32_t i = 0; i < tilebuilder.header()->nodecount(); i++) {
       GraphId startnode(id, local_level, i);
       NodeInfoBuilder nodeinfo = tilebuilder.node(i);
 
@@ -861,12 +845,10 @@ void enhance(const boost::property_tree::ptree& pt, GraphReader& reader, IdTable
         nodeinfo.set_local_driveability(j, driveability);
       }
 
-      // Go through directed edges and update data
+      // Go through directed edges and "enhance" directed edge attributes
       const DirectedEdge* edges = tile->directededge(nodeinfo.edge_index());
       for (uint32_t j = 0; j <  nodeinfo.edge_count(); j++) {
         DirectedEdgeBuilder& directededge = tilebuilder.directededge(nodeinfo.edge_index() + j);
-        // Enhance directed edge attributes. TODO - drive_on_right flag
-        // and other admin related processing
 
         // Update speed.
         UpdateSpeed(directededge, density);
@@ -951,6 +933,12 @@ void enhance(const boost::property_tree::ptree& pt, GraphReader& reader, IdTable
     GraphTileHeaderBuilder hdrbuilder =
           static_cast<GraphTileHeaderBuilder&>(existinghdr);
     tilebuilder.Update(tile_hierarchy, hdrbuilder, nodes, directededges);
+    LOG_TRACE((boost::format("GraphEnhancer completed tile %1%") % tile_id).str());
+
+    // Check if we need to clear the tile cache
+    if (reader.OverCommitted()) {
+      reader.Clear();
+    }
     lock.unlock();
   }
 
@@ -968,17 +956,33 @@ namespace mjolnir {
 
 // Enhance the local level of the graph
 void GraphEnhancer::Enhance(const boost::property_tree::ptree& pt) {
-
-  // Graphreader
-  GraphReader reader(pt.get_child("mjolnir.hierarchy"));
-
-  // A place to hold worker threads and their results, be they exceptions or otherwise
+  // A place to hold worker threads and their results, exceptions or otherwise
   std::vector<std::shared_ptr<std::thread> > threads(
-    std::max(static_cast<unsigned int>(1), pt.get<unsigned int>("concurrency", std::thread::hardware_concurrency())));
-  // A place to hold the results of those threads, be they exceptions or otherwise
+    std::max(static_cast<unsigned int>(1),
+    pt.get<unsigned int>("concurrency", std::thread::hardware_concurrency())));
+
+  // A place to hold the results of those threads, exceptions or otherwise
   std::list<std::promise<enhancer_stats> > results;
-  // A place for the threads to synchronize who is working/worked on what
-  IdTable done_set(reader.GetTileHierarchy().levels().rbegin()->second.tiles.TileCount());
+
+  // Create a randomized queue of tiles to work from
+  std::deque<GraphId> tempqueue;
+  boost::property_tree::ptree hierarchy_properties = pt.get_child("mjolnir.hierarchy");
+  GraphReader reader(hierarchy_properties);
+  auto tile_hierarchy = reader.GetTileHierarchy();
+  auto local_level = tile_hierarchy.levels().rbegin()->second.level;
+  auto tiles = tile_hierarchy.levels().rbegin()->second.tiles;
+  for (uint32_t id = 0; id < tiles.TileCount(); id++) {
+    // If tile exists add it to the queue
+    GraphId tile_id(id, local_level, 0);
+    if (GraphReader::DoesTileExist(tile_hierarchy, tile_id)) {
+      tempqueue.push_back(tile_id);
+    }
+  }
+  std::random_shuffle(tempqueue.begin(), tempqueue.end());
+  std::queue<GraphId> tilequeue(tempqueue);
+  LOG_INFO("Done creating queue of tiles: count = " +
+           std::to_string(tilequeue.size()));
+
   // An atomic object we can use to do the synchronization
   std::mutex lock;
 
@@ -986,7 +990,10 @@ void GraphEnhancer::Enhance(const boost::property_tree::ptree& pt) {
   LOG_INFO("Enhancing local graph...");
   for (auto& thread : threads) {
     results.emplace_back();
-    thread.reset(new std::thread(enhance, std::ref(pt.get_child("mjolnir.admin")), std::ref(reader), std::ref(done_set), std::ref(lock), std::ref(results.back())));
+    thread.reset(new std::thread(enhance,
+                 std::ref(pt.get_child("mjolnir.admin")),
+                 std::ref(hierarchy_properties), std::ref(tilequeue),
+                 std::ref(lock), std::ref(results.back())));
   }
 
   // Wait for them to finish up their work


### PR DESCRIPTION
Use local GraphReader so we can clear cache to limit memory use.
Add a queue of tiles, randomized so threads are not likely to be working on adjacent tiles.