### PR TITLE
Update ReclassifyLinks

### DIFF
--- a/valhalla/mjolnir/osmnode.h
+++ b/valhalla/mjolnir/osmnode.h
@@ -22,7 +22,8 @@ struct NodeAttributes {
   uint32_t backward_signal  : 1;
   uint32_t non_link_edge    : 1;
   uint32_t link_edge        : 1;
-  uint32_t spare            : 4;
+  uint32_t shortlink        : 1;  // Link edge < kMaxInternalLength
+  uint32_t spare            : 3;
 };
 
 /**


### PR DESCRIPTION
Update ConstructEdge to flag short link edges. Update ReclassifyLinks to use the shortlink flag to expand at nodes with non-link edges only if a short link is present (likely to be internal to an intersection)