### PR TITLE
Fix bug where edges with exitsigns were not marked.

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -755,7 +755,7 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
           // Any exits for this directed edge? is auto and oneway?
           std::vector<SignInfo> exits = GraphBuilder::CreateExitSignInfoList(node, w, osmdata);
           if (!exits.empty() && directededge.forwardaccess()
-               && directededge.use() == Use::kRamp) {
+               && directededge.link()) {
             graphtile.AddSigns(idx, exits);
             directededge.set_exitsign(true);
           }

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -55,6 +55,12 @@ void GraphTileBuilder::StoreTileData(const baldr::TileHierarchy& hierarchy,
         (sizeof(GraphTileHeaderBuilder))
             + (nodes_builder_.size() * sizeof(NodeInfoBuilder))
             + (directededges_builder_.size() * sizeof(DirectedEdgeBuilder))
+            + (departures_.size() * sizeof(TransitDeparture))
+            + (transit_trips_.size() * sizeof(TransitTrip))
+            + (transit_stops_.size() * sizeof(TransitStop))
+            + (transit_routes_.size() * sizeof(TransitRoute))
+            + (transit_transfers_.size() * sizeof(TransitTransfer))
+            + (transit_exceptions_.size() * sizeof(TransitCalendar))
             + (signs_builder_.size() * sizeof(SignBuilder))
             + (admins_builder_.size() * sizeof(AdminInfoBuilder)));
 

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -43,6 +43,12 @@ void GraphTileBuilder::StoreTileData(const baldr::TileHierarchy& hierarchy,
     header_builder_.set_graphid(graphid);
     header_builder_.set_nodecount(nodes_builder_.size());
     header_builder_.set_directededgecount(directededges_builder_.size());
+    header_builder_.set_departurecount(departures_.size());
+    header_builder_.set_tripcount(transit_trips_.size());
+    header_builder_.set_stopcount(transit_stops_.size());
+    header_builder_.set_routecount(transit_routes_.size());
+    header_builder_.set_transfercount(transit_transfers_.size());
+    header_builder_.set_calendarcount(transit_exceptions_.size());
     header_builder_.set_signcount(signs_builder_.size());
     header_builder_.set_admincount(admins_builder_.size());
     header_builder_.set_edgeinfo_offset(


### PR DESCRIPTION
 Check if a link, not Use = ramp. Ramp/turn channel use assignment is now in GraphEnhancer