### PR TITLE
Transit additions. Method to add names to textlist

### DIFF
--- a/src/mjolnir/edgeinfobuilder.cc
+++ b/src/mjolnir/edgeinfobuilder.cc
@@ -24,9 +24,20 @@ void EdgeInfoBuilder::set_text_name_offset_list(
   text_name_offset_list_ = text_name_offset_list;
 }
 
+// Set the indexes to names used by this edge.
+void EdgeInfoBuilder::AddNameOffset(const uint32_t offset) {
+  text_name_offset_list_.push_back(offset);
+}
+
 // Set the shape of the edge. Encode the vector of lat,lng to a string.
 void EdgeInfoBuilder::set_shape(const std::vector<PointLL>& shape) {
   encoded_shape_ = midgard::encode<std::vector<PointLL> >(shape);
+}
+
+// Set the encoded shape string.
+void EdgeInfoBuilder::set_encoded_shape(const std::string& encoded_shape) {
+  std::copy(encoded_shape.begin(),encoded_shape.end(),
+            back_inserter(encoded_shape_));
 }
 
 // Get the size of the edge info (including name offsets and shape string)

--- a/src/mjolnir/edgeinfobuilder.cc
+++ b/src/mjolnir/edgeinfobuilder.cc
@@ -10,10 +10,7 @@
 namespace valhalla {
 namespace mjolnir {
 
-/**
- * Set the OSM way Id.
- * @param wayid  Way Id.
- */
+// Set the OSM way Id.
 void EdgeInfoBuilder::set_wayid(const uint64_t wayid) {
   wayid_ = wayid;
 }
@@ -36,7 +33,7 @@ void EdgeInfoBuilder::set_shape(const std::vector<PointLL>& shape) {
 
 // Set the encoded shape string.
 void EdgeInfoBuilder::set_encoded_shape(const std::string& encoded_shape) {
-  std::copy(encoded_shape.begin(),encoded_shape.end(),
+  std::copy(encoded_shape.begin(), encoded_shape.end(),
             back_inserter(encoded_shape_));
 }
 
@@ -49,6 +46,7 @@ std::size_t EdgeInfoBuilder::SizeOf() const {
   return size;
 }
 
+// Output edge info to output stream
 std::ostream& operator<<(std::ostream& os, const EdgeInfoBuilder& eib) {
   // Pack the name count and encoded shape size. Check against limits.
   baldr::EdgeInfo::PackedItem item;

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -362,9 +362,8 @@ bool IsIntersectionInternal(GraphReader& reader, std::mutex& lock,
                             DirectedEdgeBuilder& directededge,
                             const uint32_t idx) {
   // Internal intersection edges must be short and cannot be a roundabout
-  if (directededge.use() < Use::kRail &&
-      (directededge.length() > kMaxInternalLength ||
-      directededge.roundabout())) {
+  if (directededge.length() > kMaxInternalLength ||
+      directededge.roundabout()) {
     return false;
   }
 
@@ -865,7 +864,8 @@ void enhance(const boost::property_tree::ptree& pt,
     GraphId tile_id = tilequeue.front();
     uint32_t id  = tile_id.tileid();
     tilequeue.pop();
-    GraphTileBuilder tilebuilder(tile_hierarchy, tile_id, false);
+    // Tile builder - serialize in existing tile so we can add admin names
+    GraphTileBuilder tilebuilder(tile_hierarchy, tile_id, true);
     const GraphTile* tile = reader.GetGraphTile(tile_id);
     lock.unlock();
 
@@ -885,15 +885,12 @@ void enhance(const boost::property_tree::ptree& pt,
       }
     }
 
-    // Update nodes and directed edges as needed
-    std::vector<NodeInfoBuilder> nodes;
-    std::vector<DirectedEdgeBuilder> directededges;
-
-    // Iterate through the nodes
+    // Iterate through the nodes. Update nodeinfo and directed edges as
+    // needed
     const GraphTile* endnodetile = nullptr;
     for (uint32_t i = 0; i < tilebuilder.header()->nodecount(); i++) {
       GraphId startnode(id, local_level, i);
-      NodeInfoBuilder nodeinfo = tilebuilder.node(i);
+      NodeInfoBuilder& nodeinfo = tilebuilder.node_builder(i);
 
       // Get relative road density and local density
       uint32_t density = GetDensity(reader, lock, nodeinfo.latlng(),
@@ -923,8 +920,9 @@ void enhance(const boost::property_tree::ptree& pt,
       uint32_t heading[ntrans];
       nodeinfo.set_local_edge_count(ntrans);
       for (uint32_t j = 0; j < ntrans; j++) {
-        DirectedEdgeBuilder& directededge = tilebuilder.directededge(nodeinfo.edge_index() + j);
-        auto shape = tile->edgeinfo(directededge.edgeinfo_offset())->shape();
+        DirectedEdgeBuilder& directededge =
+            tilebuilder.directededge_builder(nodeinfo.edge_index() + j);
+        auto shape = tilebuilder.edgeinfo(directededge.edgeinfo_offset())->shape();
         if (!directededge.forward())
           std::reverse(shape.begin(), shape.end());
         heading[j] = std::round(PointLL::HeadingAlongPolyline(shape, kMetersOffsetForHeading));
@@ -949,7 +947,8 @@ void enhance(const boost::property_tree::ptree& pt,
       // Go through directed edges and "enhance" directed edge attributes
       const DirectedEdge* edges = tile->directededge(nodeinfo.edge_index());
       for (uint32_t j = 0; j <  nodeinfo.edge_count(); j++) {
-        DirectedEdgeBuilder& directededge = tilebuilder.directededge(nodeinfo.edge_index() + j);
+        DirectedEdgeBuilder& directededge =
+            tilebuilder.directededge_builder(nodeinfo.edge_index() + j);
 
         // Get the tile at the end node
         if (tile->id() == directededge.endnode().Tile_Base()) {
@@ -960,7 +959,7 @@ void enhance(const boost::property_tree::ptree& pt,
           lock.unlock();
         }
 
-        // If this edge is a link, update its use (potenitally change short
+        // If this edge is a link, update its use (potentially change short
         // links to turn channels)
         if (directededge.link()) {
           UpdateLinkUse(tile, endnodetile, nodeinfo, directededge);
@@ -985,46 +984,45 @@ void enhance(const boost::property_tree::ptree& pt,
 
         // Name continuity - set in NodeInfo
         for (uint32_t k = (j + 1); k < ntrans; k++) {
-          if (ConsistentNames(
-              country_code,
-              tile->edgeinfo(directededge.edgeinfo_offset())->GetNames(),
-              tile->edgeinfo(
+          if (ConsistentNames(country_code,
+              tilebuilder.edgeinfo(directededge.edgeinfo_offset())->GetNames(),
+              tilebuilder.edgeinfo(
                   tilebuilder.directededge(nodeinfo.edge_index() + k)
                       .edgeinfo_offset())->GetNames())) {
             nodeinfo.set_name_consistency(j, k, true);
           }
         }
 
-        // Set unreachable (driving) flag
-        if (IsUnreachable(reader, lock, directededge)) {
-          directededge.set_unreachable(true);
-          stats.unreachable++;
-        }
+        // Set unreachable, not_thru, or internal intersection (except
+        // for transit)
+        if (directededge.use() < Use::kRail) {
+          // Set unreachable (driving) flag
+          if (IsUnreachable(reader, lock, directededge)) {
+            directededge.set_unreachable(true);
+            stats.unreachable++;
+          }
 
-        // Check for not_thru edge (only on low importance edges). Exclude
-        // transit edges
-        if (directededge.classification() > RoadClass::kTertiary &&
-            directededge.use() < Use::kRail) {
-          if (IsNotThruEdge(reader, lock, startnode, directededge)) {
-            directededge.set_not_thru(true);
-            stats.not_thru++;
+          // Check for not_thru edge (only on low importance edges). Exclude
+          // transit edges
+          if (directededge.classification() > RoadClass::kTertiary) {
+            if (IsNotThruEdge(reader, lock, startnode, directededge)) {
+              directededge.set_not_thru(true);
+              stats.not_thru++;
+            }
+          }
+
+          // Test if an internal intersection edge. Must do this after setting
+          // opposing edge index
+          if (IsIntersectionInternal(reader, lock, startnode, nodeinfo,
+                                      directededge, j)) {
+            directededge.set_internal(true);
+            stats.internalcount++;
           }
         }
 
         // Set the opposing index on the local level
         directededge.set_opp_local_idx(
             GetOpposingEdgeIndex(endnodetile, startnode, directededge));
-
-        // Test if an internal intersection edge. Must do this after setting
-        // opposing edge index
-        if (IsIntersectionInternal(reader, lock, startnode, nodeinfo,
-                                   directededge, j)) {
-          directededge.set_internal(true);
-          stats.internalcount++;
-        }
-
-        // Add the directed edge
-        directededges.emplace_back(std::move(directededge));
       }
 
       // Set the intersection type
@@ -1038,17 +1036,11 @@ void enhance(const boost::property_tree::ptree& pt,
           nodeinfo.set_intersection(IntersectionType::kFalse);
         }
       }
-
-      // Add the node to the list
-      nodes.emplace_back(std::move(nodeinfo));
     }
 
     // Write the new file
     lock.lock();
-    GraphTileHeader existinghdr = *(tilebuilder.header());
-    GraphTileHeaderBuilder hdrbuilder =
-          static_cast<GraphTileHeaderBuilder&>(existinghdr);
-    tilebuilder.Update(tile_hierarchy, hdrbuilder, nodes, directededges);
+    tilebuilder.StoreTileData(tile_hierarchy, tile_id);
     LOG_TRACE((boost::format("GraphEnhancer completed tile %1%") % tile_id).str());
 
     // Check if we need to clear the tile cache

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -14,14 +14,112 @@ namespace mjolnir {
 // Constructor
 GraphTileBuilder::GraphTileBuilder()
     : GraphTile() {
+  // Add an empty name to the list so offset 0 means blank name
+  AddName("");
 }
 
 // Constructor given an existing tile. This is used to read in the tile
 // data and then add to it (e.g. adding node connections between hierarchy
-// levels.
+// levels. If the deserialize flag is set then all objects are serialized
+// from memory into builders that can be added to and then stored using
+// StoreTileData.
 GraphTileBuilder::GraphTileBuilder(const baldr::TileHierarchy& hierarchy,
-                                   const GraphId& graphid)
+                                   const GraphId& graphid, bool deserialize)
     : GraphTile(hierarchy, graphid) {
+  // Add an empty name to the list so offset 0 means blank name
+  AddName("");
+
+  if (!deserialize) {
+    // Done if not deserializing and creating builders for everything
+    return;
+  }
+
+  // Copy tile header to a builder
+  GraphTileHeader existinghdr = *(header_);
+  header_builder_ = static_cast<GraphTileHeaderBuilder&>(existinghdr);
+
+  // Unique set of offsets into the text list
+  std::set<uint32_t> text_offsets;
+
+  // Create vectors of the fixed size objects
+  size_t n = header_->nodecount();
+  nodes_builder_.resize(n);
+  memcpy(&nodes_builder_[0], nodes_, n * sizeof(NodeInfo));
+  n = header_->directededgecount();
+  directededges_builder_.resize(n);
+  memcpy(&directededges_builder_[0], directededges_, n * sizeof(DirectedEdge));
+
+  // TODO - replace this? Need to add to text list offsets
+  std::copy(departures_, departures_ + header_->departurecount(),
+              std::back_inserter(departure_builder_));
+  std::copy(transit_trips_, transit_trips_ + header_->tripcount(),
+                std::back_inserter(trip_builder_));
+  std::copy(transit_stops_, transit_stops_ + header_->stopcount(),
+                std::back_inserter(stop_builder_));
+  std::copy(transit_routes_, transit_routes_ + header_->routecount(),
+                std::back_inserter(route_builder_));
+  std::copy(transit_transfers_, transit_transfers_ + header_->transfercount(),
+                std::back_inserter(transfer_builder_));
+  std::copy(transit_exceptions_, transit_exceptions_ + header_->calendarcount(),
+                std::back_inserter(exception_builder_));
+
+  // Create sign builders
+  for (uint32_t i = 0; i < header_->signcount(); i++) {
+    text_offsets.insert(signs_[i].text_offset());
+    signs_builder_.emplace_back(signs_[i].edgeindex(), signs_[i].type(),
+                                signs_[i].text_offset());
+  }
+
+  // Create admin builders
+  for (uint32_t i = 0; i < header_->admincount(); i++) {
+    admins_builder_.emplace_back(admins_[i].country_offset(),
+                admins_[i].state_offset(), admins_[i].country_iso(),
+                admins_[i].state_iso(),admins_[i].start_dst(),
+                admins_[i].end_dst());
+    text_offsets.insert(admins_[i].country_offset());
+    text_offsets.insert(admins_[i].state_offset());
+  }
+
+  // Create an ordered set of edge info offsets
+  std::set<uint32_t> edge_info_offsets;
+  for (auto& diredge : directededges_builder_) {
+    edge_info_offsets.insert(diredge.edgeinfo_offset());
+  }
+
+  // EdgeInfo. Create list of EdgeInfoBuilders. Add to text offset set.
+  edge_info_offset_ = 0;
+  for (auto offset : edge_info_offsets) {
+    // Verify the offsets match as we create the edge info builder list
+    if (offset != edge_info_offset_) {
+      LOG_ERROR("offset = " + std::to_string(offset) + " ei offset= " +
+                std::to_string(edge_info_offset_));
+    }
+    EdgeInfo ei(edgeinfo_ + offset, textlist_, textlist_size_);
+    EdgeInfoBuilder eib;
+    eib.set_wayid(ei.wayid());
+    for (uint32_t nm = 0; nm < ei.name_count(); nm++) {
+      uint32_t name_offset = ei.GetStreetNameOffset(nm);
+      text_offsets.insert(name_offset);
+      eib.AddNameOffset(name_offset);
+    }
+    eib.set_encoded_shape(ei.encoded_shape());
+    edge_info_offset_ += eib.SizeOf();
+    edgeinfo_list_.emplace_back(std::move(eib));
+  }
+
+  // Text list
+  uint32_t sz = 0;
+  for (auto offset : text_offsets) {
+    // Verify offsets as we add text
+    if (offset != sz) {
+      LOG_ERROR("Text offset = " + std::to_string(offset) + " sz= " +
+                      std::to_string(sz));
+    }
+    std::string str(textlist_ + offset);
+    textlistbuilder_.push_back(str);
+    text_offset_map.emplace(str, offset);
+    sz += str.length() + 1;
+  }
 }
 
 // Output the tile to file. Stores as binary data.
@@ -35,32 +133,32 @@ void GraphTileBuilder::StoreTileData(const baldr::TileHierarchy& hierarchy,
   if (!boost::filesystem::exists(filename.parent_path()))
     boost::filesystem::create_directories(filename.parent_path());
 
-  // Open to the end of the file so we can immediately get size;
+  // Open file and truncate
   std::ofstream file(filename.c_str(),
-                     std::ios::out | std::ios::binary | std::ios::ate);
+                     std::ios::out | std::ios::binary | std::ios::trunc);
   if (file.is_open()) {
     // Configure the header
     header_builder_.set_graphid(graphid);
     header_builder_.set_nodecount(nodes_builder_.size());
     header_builder_.set_directededgecount(directededges_builder_.size());
-    header_builder_.set_departurecount(departures_.size());
-    header_builder_.set_tripcount(transit_trips_.size());
-    header_builder_.set_stopcount(transit_stops_.size());
-    header_builder_.set_routecount(transit_routes_.size());
-    header_builder_.set_transfercount(transit_transfers_.size());
-    header_builder_.set_calendarcount(transit_exceptions_.size());
+    header_builder_.set_departurecount(departure_builder_.size());
+    header_builder_.set_tripcount(trip_builder_.size());
+    header_builder_.set_stopcount(stop_builder_.size());
+    header_builder_.set_routecount(route_builder_.size());
+    header_builder_.set_transfercount(transfer_builder_.size());
+    header_builder_.set_calendarcount(exception_builder_.size());
     header_builder_.set_signcount(signs_builder_.size());
     header_builder_.set_admincount(admins_builder_.size());
     header_builder_.set_edgeinfo_offset(
         (sizeof(GraphTileHeaderBuilder))
             + (nodes_builder_.size() * sizeof(NodeInfoBuilder))
             + (directededges_builder_.size() * sizeof(DirectedEdgeBuilder))
-            + (departures_.size() * sizeof(TransitDeparture))
-            + (transit_trips_.size() * sizeof(TransitTrip))
-            + (transit_stops_.size() * sizeof(TransitStop))
-            + (transit_routes_.size() * sizeof(TransitRoute))
-            + (transit_transfers_.size() * sizeof(TransitTransfer))
-            + (transit_exceptions_.size() * sizeof(TransitCalendar))
+            + (departure_builder_.size() * sizeof(TransitDeparture))
+            + (trip_builder_.size() * sizeof(TransitTrip))
+            + (stop_builder_.size() * sizeof(TransitStop))
+            + (route_builder_.size() * sizeof(TransitRoute))
+            + (transfer_builder_.size() * sizeof(TransitTransfer))
+            + (exception_builder_.size() * sizeof(TransitCalendar))
             + (signs_builder_.size() * sizeof(SignBuilder))
             + (admins_builder_.size() * sizeof(AdminInfoBuilder)));
 
@@ -80,34 +178,34 @@ void GraphTileBuilder::StoreTileData(const baldr::TileHierarchy& hierarchy,
                directededges_builder_.size() * sizeof(DirectedEdgeBuilder));
 
     // Sort and write the transit departures
-    std::sort(departures_.begin(), departures_.end());
-    file.write(reinterpret_cast<const char*>(&departures_[0]),
-               departures_.size() * sizeof(TransitDeparture));
+    std::sort(departure_builder_.begin(), departure_builder_.end());
+    file.write(reinterpret_cast<const char*>(&departure_builder_[0]),
+               departure_builder_.size() * sizeof(TransitDeparture));
 
     // Sort and write the transit trips
-    std::sort(transit_trips_.begin(), transit_trips_.end());
-    file.write(reinterpret_cast<const char*>(&transit_trips_[0]),
-               transit_trips_.size() * sizeof(TransitTrip));
+    std::sort(trip_builder_.begin(), trip_builder_.end());
+    file.write(reinterpret_cast<const char*>(&trip_builder_[0]),
+               trip_builder_.size() * sizeof(TransitTrip));
 
     // Sort and write the transit stops
-    std::sort(transit_stops_.begin(), transit_stops_.end());
-    file.write(reinterpret_cast<const char*>(&transit_stops_[0]),
-               transit_stops_.size() * sizeof(TransitStop));
+    std::sort(stop_builder_.begin(), stop_builder_.end());
+    file.write(reinterpret_cast<const char*>(&stop_builder_[0]),
+               stop_builder_.size() * sizeof(TransitStop));
 
     // Sort and write the transit routes
-    std::sort(transit_routes_.begin(), transit_routes_.end());
-    file.write(reinterpret_cast<const char*>(&transit_routes_[0]),
-               transit_routes_.size() * sizeof(TransitRoute));
+    std::sort(route_builder_.begin(), route_builder_.end());
+    file.write(reinterpret_cast<const char*>(&route_builder_[0]),
+               route_builder_.size() * sizeof(TransitRoute));
 
     // Sort and write the transit transfers
-    std::sort(transit_transfers_.begin(), transit_transfers_.end());
-    file.write(reinterpret_cast<const char*>(&transit_transfers_[0]),
-               transit_transfers_.size() * sizeof(TransitTransfer));
+    std::sort(transfer_builder_.begin(), transfer_builder_.end());
+    file.write(reinterpret_cast<const char*>(&transfer_builder_[0]),
+               transfer_builder_.size() * sizeof(TransitTransfer));
 
     // Sort and write the transit calendar exceptions
-    std::sort(transit_exceptions_.begin(), transit_exceptions_.end());
-    file.write(reinterpret_cast<const char*>(&transit_exceptions_[0]),
-               transit_exceptions_.size() * sizeof(TransitCalendar));
+    std::sort(exception_builder_.begin(), exception_builder_.end());
+    file.write(reinterpret_cast<const char*>(&exception_builder_[0]),
+               exception_builder_.size() * sizeof(TransitCalendar));
 
     // Write the signs
     file.write(reinterpret_cast<const char*>(&signs_builder_[0]),
@@ -123,8 +221,10 @@ void GraphTileBuilder::StoreTileData(const baldr::TileHierarchy& hierarchy,
     // Write the names
     SerializeTextListToOstream(file);
 
-    LOG_DEBUG((boost::format("Write: %1% nodes = %2% directededges = %3% signs %4% edgeinfo offset = %5% textlist offset = %6% admininfo offset = %7%" )
-            % filename % nodes_builder_.size() % directededges_builder_.size() % signs_builder_.size() % edge_info_offset_ % text_list_offset_ % admin_info_offset_).str());
+    LOG_DEBUG((boost::format("Write: %1% nodes = %2% directededges = %3% signs %4% edgeinfo offset = %5% textlist offset = %6%" )
+      % filename % nodes_builder_.size() % directededges_builder_.size() % signs_builder_.size() % edge_info_offset_ % text_list_offset_).str());
+    LOG_DEBUG((boost::format("   admins = %1%  departures = %2% stops = %3% trips %4% routes = %5%" )
+      % admins_builder_.size() % departure_builder_.size() % stop_builder_.size() % trip_builder_.size() % route_builder_.size()).str());
 
     /*   size_t fsize = file.tellp();
      if (fsize % 8 != 0) {
@@ -382,75 +482,56 @@ void GraphTileBuilder::AddNodeAndDirectedEdges(
   // Add the node to the list
   nodes_builder_.push_back(node);
 
-  // For each directed edge need to set its common edge offset
+  // Add directed edges to the list
   for (const auto& directededge : directededges) {
-    // Add the directed edge to the list
     directededges_builder_.push_back(directededge);
   }
 }
 
 // Add a transit departure.
 void GraphTileBuilder::AddTransitDeparture(const TransitDeparture& departure) {
-  departures_.emplace_back(departure);
+  departure_builder_.emplace_back(departure);
 }
 
 // Add a transit trip.
 void GraphTileBuilder::AddTransitTrip(const TransitTrip& trip) {
-  transit_trips_.emplace_back(trip);
+  trip_builder_.emplace_back(trip);
 }
 
 // Add a transit stop.
 void GraphTileBuilder::AddTransitStop(const TransitStop& stop)  {
-  transit_stops_.emplace_back(stop);
+  stop_builder_.emplace_back(stop);
 }
 
 // Add a transit route.
 void GraphTileBuilder::AddTransitRoute(const TransitRoute& route)  {
-  transit_routes_.emplace_back(route);
+  route_builder_.emplace_back(route);
 }
 
 // Add a transit transfer.
 void GraphTileBuilder::AddTransitTransfer(const TransitTransfer& transfer)  {
-  transit_transfers_.emplace_back(transfer);
+  transfer_builder_.emplace_back(transfer);
 }
 
 // Add a transit calendar exception.
 void GraphTileBuilder::AddTransitCalendar(const TransitCalendar& exception)  {
-  transit_exceptions_.emplace_back(exception);
+  exception_builder_.emplace_back(exception);
 }
 
 // Add signs
 void GraphTileBuilder::AddSigns(const uint32_t idx,
                                 const std::vector<SignInfo>& signs) {
-  // Iterate through the list of sign info (with sign text)
+  // Iterate through the list of sign info (with sign text) and add sign
+  // text to the text list. Skip signs with no text.
   for (const auto& sign : signs) {
-    // Skip signs with no sign text
-    if (sign.text().empty()) {
-      continue;
-    }
-
-    // If nothing already used this sign text
-    auto existing_text_offset = text_offset_map.find(sign.text());
-    if (existing_text_offset == text_offset_map.end()) {
-      // Add name to text list
-      textlistbuilder_.emplace_back(sign.text());
-
-      // Add sign to the list
-      signs_builder_.emplace_back(idx, sign.type(), text_list_offset_);
-
-      // Add text/offset pair to map
-      text_offset_map.emplace(sign.text(), text_list_offset_);
-
-      // Update text offset value to length of string plus null terminator
-      text_list_offset_ += (sign.text().length() + 1);
-    } else {
-      // Name already exists. Add sign type and existing text offset to list
-      signs_builder_.emplace_back(idx, sign.type(),
-                                  existing_text_offset->second);
+    if (!(sign.text().empty())) {
+      uint32_t offset = AddName(sign.text());
+      signs_builder_.emplace_back(idx, sign.type(), offset);
     }
   }
 }
 
+// Add edge info
 uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
                                        const GraphId& nodea,
                                        const baldr::GraphId& nodeb,
@@ -468,35 +549,14 @@ uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
     edgeinfo.set_wayid(wayid);
     edgeinfo.set_shape(lls);
 
-    ///////////////////////////////////////////////////////////////////////////
-    // Put each name's index into the chunk of bytes containing all the names
-    // in the tile
+    // Add names to the common text/name list. Skip blank names.
     std::vector<uint32_t> text_name_offset_list;
     text_name_offset_list.reserve(names.size());
     for (const auto& name : names) {
-      // Skip blank names
-      if (name.empty()) {
-        continue;
-      }
-
-      // If nothing already used this name
-      auto existing_text_offset = text_offset_map.find(name);
-      if (existing_text_offset == text_offset_map.end()) {
-        // Add name to text list
-        textlistbuilder_.emplace_back(name);
-
-        // Add name offset to list
-        text_name_offset_list.emplace_back(text_list_offset_);
-
-        // Add name/offset pair to map
-        text_offset_map.emplace(name, text_list_offset_);
-
-        // Update text offset value to length of string plus null terminator
-        text_list_offset_ += (name.length() + 1);
-      }  // Something was already using this name
-      else {
-        // Add existing offset to list
-        text_name_offset_list.emplace_back(existing_text_offset->second);
+      if (!(name.empty())) {
+        // Add name and add its offset to edge info's list.
+        uint32_t offset = AddName(name);
+        text_name_offset_list.emplace_back(offset);
       }
     }
     edgeinfo.set_text_name_offset_list(text_name_offset_list);
@@ -520,89 +580,52 @@ uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
   }
 }
 
-// Get admin index
-uint32_t GraphTileBuilder::GetAdminIndex(const std::string& country_iso) {
-
-  auto existing_admin_info_offset_item = admin_info_offset_map.find(country_iso);
-  if (existing_admin_info_offset_item == admin_info_offset_map.end())
+// Add a name to the text list
+uint32_t GraphTileBuilder::AddName(const std::string& name) {
+  if (name.empty()) {
     return 0;
-  return existing_admin_info_offset_item->second;
+  }
+
+  // If nothing already used this name
+  auto existing_text_offset = text_offset_map.find(name);
+  if (existing_text_offset == text_offset_map.end()) {
+    // Save the current offset and add name to text list
+    uint32_t offset = text_list_offset_;
+    textlistbuilder_.emplace_back(name);
+
+    // Add name/offset pair to map and update text offset value
+    // to length of string plus null terminator
+    text_offset_map.emplace(name, text_list_offset_);
+    text_list_offset_ += (name.length() + 1);
+    return offset;
+  } else {
+    // Return the offset to the existing name
+    return existing_text_offset->second;
+  }
 }
 
 // Add admin
-uint32_t GraphTileBuilder::AddAdmin(const std::string& country_name, const std::string& state_name,
-                                    const std::string& country_iso, const std::string& state_iso,
-                                    const std::string& start_dst, const std::string& end_dst) {
-
+uint32_t GraphTileBuilder::AddAdmin(const std::string& country_name,
+            const std::string& state_name, const std::string& country_iso,
+            const std::string& state_iso,const std::string& start_dst,
+            const std::string& end_dst) {
+  // Check if admin already exists
   auto existing_admin_info_offset_item = admin_info_offset_map.find(country_iso+state_name);
   if (existing_admin_info_offset_item == admin_info_offset_map.end()) {
-
-    uint32_t country_offset = 0;
-    uint32_t state_offset = 0;
-
-    if (!country_name.empty()) {
-      // If nothing already used this admin text
-      auto existing_text_offset = text_offset_map.find(country_name);
-      if (existing_text_offset == text_offset_map.end()) {
-        // Add name to text list
-        textlistbuilder_.emplace_back(country_name);
-
-        // Append to the list. Get the size of the current list
-        if (text_list_offset_ == 0)
-          text_list_offset_ = textlist_size_;
-
-        country_offset = text_list_offset_;
-
-        // Add text/offset pair to map
-        text_offset_map.emplace(country_name, text_list_offset_);
-
-        // Update text offset value to length of string plus null terminator
-        text_list_offset_ += (country_name.length() + 1);
-      } else {
-        // Name already exists. Add sign type and existing text offset to list
-        country_offset = existing_text_offset->second;
-      }
-    }
-
-    if (!state_name.empty()) {
-      // If nothing already used this admin text
-      auto existing_text_offset = text_offset_map.find(state_name);
-      if (existing_text_offset == text_offset_map.end()) {
-        // Add name to text list
-        textlistbuilder_.emplace_back(state_name);
-
-        // Append to the list. Get the size of the current list
-        if (text_list_offset_ == 0)
-          text_list_offset_ = textlist_size_;
-
-        state_offset = text_list_offset_;
-
-        // Add text/offset pair to map
-        text_offset_map.emplace(state_name, text_list_offset_);
-
-        // Update text offset value to length of string plus null terminator
-        text_list_offset_ += (state_name.length() + 1);
-      } else {
-        // Name already exists. Add sign type and existing text offset to list
-        state_offset = existing_text_offset->second;
-      }
-    }
-
-    // Add admin to the list
+    // Add names and add to the admin builder
+    uint32_t country_offset = AddName(country_name);
+    uint32_t state_offset   = AddName(state_name);
     admins_builder_.emplace_back(country_offset, state_offset,
                                  country_iso, state_iso,
                                  start_dst, end_dst);
 
     // Add to the map
     admin_info_offset_map.emplace(country_iso+state_name, admins_builder_.size()-1);
-
     return admins_builder_.size()-1;
-
   } else {
     // Already have this admin - return the offset
     return existing_admin_info_offset_item->second;
   }
-
 }
 
 // Serialize the edge info list

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -470,8 +470,8 @@ uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
                                        bool& added) {
   // If we haven't yet added edge info for this edge tuple
   auto edge_tuple_item = EdgeTuple(edgeindex, nodea, nodeb);
-  auto existing_edge_offset_item = edge_offset_map.find(edge_tuple_item);
-  if (existing_edge_offset_item == edge_offset_map.end()) {
+  auto existing_edge_offset_item = edge_offset_map_.find(edge_tuple_item);
+  if (existing_edge_offset_item == edge_offset_map_.end()) {
     // Add a new EdgeInfo to the list and get a reference to it
     edgeinfo_list_.emplace_back();
     EdgeInfoBuilder& edgeinfo = edgeinfo_list_.back();
@@ -491,7 +491,7 @@ uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
     edgeinfo.set_text_name_offset_list(text_name_offset_list);
 
     // Add to the map
-    edge_offset_map.emplace(edge_tuple_item, edge_info_offset_);
+    edge_offset_map_.emplace(edge_tuple_item, edge_info_offset_);
 
     // Set current edge offset
     uint32_t current_edge_offset = edge_info_offset_;
@@ -539,8 +539,8 @@ uint32_t GraphTileBuilder::AddAdmin(const std::string& country_name,
             const std::string& state_iso,const std::string& start_dst,
             const std::string& end_dst) {
   // Check if admin already exists
-  auto existing_admin_info_offset_item = admin_info_offset_map.find(country_iso+state_name);
-  if (existing_admin_info_offset_item == admin_info_offset_map.end()) {
+  auto existing_admin_info_offset_item = admin_info_offset_map_.find(country_iso+state_name);
+  if (existing_admin_info_offset_item == admin_info_offset_map_.end()) {
     // Add names and add to the admin builder
     uint32_t country_offset = AddName(country_name);
     uint32_t state_offset   = AddName(state_name);
@@ -549,7 +549,7 @@ uint32_t GraphTileBuilder::AddAdmin(const std::string& country_name,
                                  start_dst, end_dst);
 
     // Add to the map
-    admin_info_offset_map.emplace(country_iso+state_name, admins_builder_.size()-1);
+    admin_info_offset_map_.emplace(country_iso+state_name, admins_builder_.size()-1);
     return admins_builder_.size()-1;
   } else {
     // Already have this admin - return the offset

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -154,7 +154,7 @@ void GraphValidator::Validate(const boost::property_tree::ptree& pt) {
     uint32_t ntiles = tiles.TileCount();
     for (uint32_t tileid = 0; tileid < ntiles; tileid++) {
       // Get the graph tile. Skip if no tile exists (common case)
-      GraphTileBuilder tilebuilder(tile_hierarchy_, GraphId(tileid, level, 0));
+      GraphTileBuilder tilebuilder(tile_hierarchy_, GraphId(tileid, level, 0), false);
       if (tilebuilder.size() == 0) {
         continue;
       }

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -600,12 +600,13 @@ void FormTilesInNewLevel(
 
 // Add connections to the base tile. Rewrites the base tile with updated
 // header information, node, and directed edge information.
-void AddConnectionsToBaseTile(
-    const uint32_t basetileid, const std::vector<NodeConnection>& connections, const TileHierarchy& tile_hierarchy) {
+void AddConnectionsToBaseTile(const uint32_t basetileid,
+                              const std::vector<NodeConnection>& connections,
+                              const TileHierarchy& tile_hierarchy) {
   // Read in existing tile
   uint8_t baselevel = connections[0].basenode.level();
   GraphId basetile(basetileid, baselevel, 0);
-  GraphTileBuilder tilebuilder(tile_hierarchy, basetile);
+  GraphTileBuilder tilebuilder(tile_hierarchy, basetile, false);
 
   // TODO - anything index by directed edge index (e.g. Signs) needs
   // to be updated!

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -12,7 +12,7 @@ namespace {
 
 class test_graph_tile_builder : public GraphTileBuilder {
  public:
-  using GraphTileBuilder::edge_offset_map;
+  using GraphTileBuilder::edge_offset_map_;
   using GraphTileBuilder::EdgeTupleHasher;
   using GraphTileBuilder::EdgeTuple;
 
@@ -39,11 +39,11 @@ void TestDuplicateEdgeInfo() {
   //add edge info for node 0 to node 1
   bool added = false;
   test.AddEdgeInfo(0, GraphId(0,2,0), GraphId(0,2,1), 1234, {{0, 0}, {1, 1}}, {"einzelweg"}, added);
-  if(test.edge_offset_map.size() != 1)
+  if(test.edge_offset_map_.size() != 1)
     throw std::runtime_error("There should be exactly one of these in here");
   //add edge info for node 1 to node 0
   test.AddEdgeInfo(0, GraphId(0,2,1), GraphId(0,2,0), 1234, {{1, 1}, {0, 0}}, {"einzelweg"}, added);
-  if(test.edge_offset_map.size() != 1)
+  if(test.edge_offset_map_.size() != 1)
     throw std::runtime_error("There should still be exactly one of these in here");
 }
 

--- a/valhalla/mjolnir/edgeinfobuilder.h
+++ b/valhalla/mjolnir/edgeinfobuilder.h
@@ -16,7 +16,7 @@ namespace valhalla {
 namespace mjolnir {
 
 /**
- * Edge information not required in shortest path algorithm and is
+ * Edge information. Not required in shortest path algorithm and is
  * common among the 2 directions.
   */
 class EdgeInfoBuilder {
@@ -29,18 +29,33 @@ class EdgeInfoBuilder {
 
   /**
    * Set the indexes to names used by this edge
-   * @param  text_name_offset_list  a list of name indexes.
+   * @param  offsets  List of name offsets.
    */
-  void set_text_name_offset_list(const std::vector<uint32_t>& text_name_offset_list);
+  void set_text_name_offset_list(const std::vector<uint32_t>& offsets);
+
+  /**
+   * Add a name offset to the list.
+   * @param  offset  Offset into the text list.
+   */
+  void AddNameOffset(const uint32_t offset);
 
   /**
    * Set the shape of the edge.
-   * @param  shape  the the list of lat,lng points describing the
-   * *        shape of the edge.
+   * @param  shape  List of lat,lng points describing the
+   *                shape of the edge.
    */
   void set_shape(const std::vector<PointLL>& shape);
 
-  // Returns the size in bytes of this object.
+  /**
+   * Set the encoded shape string.
+   * @param  encoded_shape  Encoded shape string
+   */
+  void set_encoded_shape(const std::string& encoded_shape);
+
+  /**
+   * Get the size of this edge info.
+   * @return  Returns the size in bytes of this object.
+   */
   std::size_t SizeOf() const;
 
  protected:
@@ -55,7 +70,6 @@ class EdgeInfoBuilder {
   std::string encoded_shape_;
 
   friend std::ostream& operator<<(std::ostream& os, const EdgeInfoBuilder& id);
-
 };
 
 }

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -70,28 +70,15 @@ class GraphTileBuilder : public baldr::GraphTile {
                      const baldr::GraphId& graphid);
 
   /**
- * Update a graph tile with new header, nodes, and directed edges. Used
- * in GraphOptimizer to update directed edge information.
- * @param hierarchy How the tiles are setup on disk
- * @param hdr Update header
- * @param nodes Update list of nodes
- * @param directededges Updated list of edges.
- */
- void Update(const baldr::TileHierarchy& hierarchy,
-             const GraphTileHeaderBuilder& hdr,
-             const std::vector<NodeInfoBuilder>& nodes,
-             const std::vector<DirectedEdgeBuilder>& directededges);
-
- /**
-* Update a graph tile with new header, nodes, and directed edges. Used
-* in GraphOptimizer to update directed edge information.
-* @param hierarchy How the tiles are setup on disk
-* @param hdr Update header
-* @param nodes Update list of nodes
-* @param directededges Updated list of edges.
-*/
-void Update(const baldr::TileHierarchy& hierarchy,
-            GraphTileHeaderBuilder& hdr,
+   * Update a graph tile with new header, nodes, and directed edges. Used
+   * in GraphValidator to update directed edge information.
+   * @param hierarchy How the tiles are setup on disk
+   * @param hdr Updated header
+   * @param nodes Updated list of nodes
+   * @param directededges Updated list of edges.
+   */
+  void Update(const baldr::TileHierarchy& hierarchy,
+            const GraphTileHeaderBuilder& hdr,
             const std::vector<NodeInfoBuilder>& nodes,
             const std::vector<DirectedEdgeBuilder>& directededges);
 
@@ -199,10 +186,22 @@ void Update(const baldr::TileHierarchy& hierarchy,
   NodeInfoBuilder& node(const size_t idx);
 
   /**
+   * Get the node builder at the specified index.
+   * @param  idx  Index of the node builder.
+   */
+  NodeInfoBuilder& node_builder(const size_t idx);
+
+  /**
    * Gets a builder for a directed edge from existing tile data.
    * @param  idx  Index of the directed edge within the tile.
    */
   DirectedEdgeBuilder& directededge(const size_t idx);
+
+  /**
+   * Get the directed edge builder at the specified index.
+   * @param  idx  Index of the directed edge builder.
+   */
+  DirectedEdgeBuilder& directededge_builder(const size_t idx);
 
   /**
    * Gets a non-const sign (builder) from existing tile data.
@@ -296,7 +295,7 @@ void Update(const baldr::TileHierarchy& hierarchy,
 
   // Text list offset and map
   uint32_t text_list_offset_ = 0;
-  std::unordered_map<std::string, uint32_t> text_offset_map;
+  std::unordered_map<std::string, uint32_t> text_offset_map_;
 
   // Text list. List of names used within this tile
   std::list<std::string> textlistbuilder_;

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -38,7 +38,6 @@ using edge_tuple = std::tuple<uint32_t, baldr::GraphId, baldr::GraphId>;
 
 /**
  * Graph information for a tile within the Tiled Hierarchical Graph.
- * @author  David W. Nesbitt
  */
 class GraphTileBuilder : public baldr::GraphTile {
  public:
@@ -50,11 +49,17 @@ class GraphTileBuilder : public baldr::GraphTile {
   /**
    * Constructor given an existing tile. This is used to read in the tile
    * data and then add to it (e.g. adding node connections between hierarchy
-   * levels.
+   * levels. If the deserialize flag is set then all objects are serialized
+   * from memory into builders that can be added to and then stored using
+   * StoreTileData.
    * @param  basedir  Base directory path
    * @param  graphid  GraphId used to determine the tileid and level
+   * @param  deserialize  If true the existing objects in the tile are
+   *                      converted into builders so they can be added to.
    */
-  GraphTileBuilder(const baldr::TileHierarchy& hierarchy, const GraphId& graphid);
+  GraphTileBuilder(const baldr::TileHierarchy& hierarchy,
+                   const GraphId& graphid,
+                   const bool deserialize);
 
   /**
    * Output the tile to file. Stores as binary data.
@@ -163,6 +168,7 @@ void Update(const baldr::TileHierarchy& hierarchy,
 
   /**
    * Add edge info to the tile.
+   * TODO - comments
    */
   uint32_t AddEdgeInfo(const uint32_t edgeindex, const baldr::GraphId& nodea,
                        const baldr::GraphId& nodeb,
@@ -170,17 +176,21 @@ void Update(const baldr::TileHierarchy& hierarchy,
                        const std::vector<PointLL>& lls,
                        const std::vector<std::string>& names,
                        bool& added);
+
+  /**
+   * Add a name to the text list.
+   * @param  name  Name/text to add.
+   * @return  Returns offset (bytes) to the name.
+   */
+  uint32_t AddName(const std::string& name);
+
   /**
    * Add admin info to the tile.
+   * TODO - comments!
    */
   uint32_t AddAdmin(const std::string& country_name, const std::string& state_name,
                     const std::string& country_iso, const std::string& state_iso,
                     const std::string& start_dst, const std::string& end_dst);
-
-  /**
-   * Get the admin index.
-   */
-  uint32_t GetAdminIndex(const std::string& country_iso);
 
   /**
    * Gets a builder for a node from an existing tile.
@@ -236,9 +246,6 @@ void Update(const baldr::TileHierarchy& hierarchy,
   // Write all textlist items to specified stream
   void SerializeTextListToOstream(std::ostream& out);
 
-  // Write all edgeinfo items to specified stream
-  void SerializeAdminInfosToOstream(std::ostream& out);
-
   // Header information for the tile
   GraphTileHeaderBuilder header_builder_;
 
@@ -252,22 +259,22 @@ void Update(const baldr::TileHierarchy& hierarchy,
 
   // List of transit departures. Sorted by directed edge Id and
   // departure time
-  std::vector<baldr::TransitDeparture> departures_;
+  std::vector<baldr::TransitDeparture> departure_builder_;
 
   // Transit trips. Sorted by trip Id.
-  std::vector<baldr::TransitTrip> transit_trips_;
+  std::vector<baldr::TransitTrip> trip_builder_;
 
   // Transit stops. Sorted by stop Id.
-  std::vector<baldr::TransitStop> transit_stops_;
+  std::vector<baldr::TransitStop> stop_builder_;
 
   // Transit route. Sorted by route Id.
-  std::vector<baldr::TransitRoute> transit_routes_;
+  std::vector<baldr::TransitRoute> route_builder_;
 
   // Transit transfers. Sorted by from stop Id.
-  std::vector<baldr::TransitTransfer> transit_transfers_;
+  std::vector<baldr::TransitTransfer> transfer_builder_;
 
   // Transit calendar exceptions. Sorted by service Id.
-  std::vector<baldr::TransitCalendar> transit_exceptions_;
+  std::vector<baldr::TransitCalendar> exception_builder_;
 
   // List of signs. This is a fixed size structure so it can be
   // indexed directly.
@@ -278,7 +285,6 @@ void Update(const baldr::TileHierarchy& hierarchy,
   std::vector<AdminInfoBuilder> admins_builder_;
 
   // Admin info offset
-  size_t admin_info_offset_ = 0;
   std::unordered_map<std::string,size_t> admin_info_offset_map;
 
   // Edge info offset and map
@@ -294,7 +300,6 @@ void Update(const baldr::TileHierarchy& hierarchy,
 
   // Text list. List of names used within this tile
   std::list<std::string> textlistbuilder_;
-
 };
 
 }

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -284,11 +284,11 @@ class GraphTileBuilder : public baldr::GraphTile {
   std::vector<AdminInfoBuilder> admins_builder_;
 
   // Admin info offset
-  std::unordered_map<std::string,size_t> admin_info_offset_map;
+  std::unordered_map<std::string,size_t> admin_info_offset_map_;
 
   // Edge info offset and map
   size_t edge_info_offset_ = 0;
-  std::unordered_map<edge_tuple, size_t, EdgeTupleHasher> edge_offset_map;
+  std::unordered_map<edge_tuple, size_t, EdgeTupleHasher> edge_offset_map_;
 
   // The edgeinfo list
   std::list<EdgeInfoBuilder> edgeinfo_list_;


### PR DESCRIPTION
Adding in transit information (except nodes and directed edges).
Add a flag to GraphTileBuilder constructor that triggers logic to read in tile data such that edges and text can be added to.
Add method (AddNames) that allows names to be added to text list. Use this for transit names and also signs, edgeinfo, and admin were ported to use it.