### PR TITLE
Add transit nodes and edges

### DIFF
--- a/src/mjolnir/pbfgraphbuilder.cc
+++ b/src/mjolnir/pbfgraphbuilder.cc
@@ -127,6 +127,9 @@ int main(int argc, char** argv) {
       return false;  //unknown value;
   }*/
 
+  // Add transit
+  TransitBuilder::Build(pt);
+
   // Enhance the local level of the graph. This adds information to the local
   // level that is usable across all levels (density, administrative
   // information (and country based attribution), edge transition logic, etc.


### PR DESCRIPTION
Add nodes for stops.
Add edges for parent/child  connections. These must have exact pairs of opposing edges.
Add edges for unique route/stop pair departures. These currently do NOT have opposing edges.
TODO - shape for edges, names (route names?), and connections to road network.