### PR TITLE
Connect transit stops to OSM edges

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -61,7 +61,8 @@ struct Edge {
     uint32_t shortlink        : 1;   // true if this is a link edge and is
                                      //   short enough it may be internal to
                                      //   an intersection
-    uint32_t spare            : 3;
+    uint32_t ferry            : 1;
+    uint32_t spare            : 2;
   };
   EdgeAttributes attributes;
 
@@ -92,6 +93,7 @@ struct Edge {
       e.attributes.driveablereverse = way.auto_backward();
     }
     e.attributes.link = way.link();
+    e.attributes.ferry = way.ferry() || way.rail();
     e.attributes.reclass_link = false;
     e.attributes.has_names = (way.name_index_ != 0
                            || way.name_en_index_ != 0
@@ -180,10 +182,13 @@ node_bundle collect_node_edges(const sequence<Node>::iterator& node_itr, sequenc
       edge.attributes.driveforward = edge.attributes.driveableforward;
       bundle.node_edges.emplace(std::make_pair(edge, node.start_of));
       bundle.node.attributes_.link_edge = bundle.node.attributes_.link_edge || edge.attributes.link;
+      bundle.node.attributes_.ferry_edge = bundle.node.attributes_.ferry_edge || edge.attributes.ferry;
       bundle.node.attributes_.shortlink |= edge.attributes.shortlink;
-      // Do not count non-driveable (e.g. emergency service roads) as a non-link edge
+      // Do not count non-driveable (e.g. emergency service roads) as a
+      // non-link edge or non-ferry edge
       if (edge.attributes.driveableforward || edge.attributes.driveablereverse) {
         bundle.node.attributes_.non_link_edge = bundle.node.attributes_.non_link_edge || !edge.attributes.link;
+        bundle.node.attributes_.non_ferry_edge = bundle.node.attributes_.non_ferry_edge || !edge.attributes.ferry;
       }
       if (edge.attributes.link) {
         bundle.link_count++;
@@ -196,10 +201,12 @@ node_bundle collect_node_edges(const sequence<Node>::iterator& node_itr, sequenc
       edge.attributes.driveforward = edge.attributes.driveablereverse;
       bundle.node_edges.emplace(std::make_pair(edge, node.end_of));
       bundle.node.attributes_.link_edge = bundle.node.attributes_.link_edge || edge.attributes.link;
+      bundle.node.attributes_.ferry_edge = bundle.node.attributes_.ferry_edge || edge.attributes.ferry;
       bundle.node.attributes_.shortlink |= edge.attributes.shortlink;
       // Do not count non-driveable (e.g. emergency service roads) as a non-link edge
       if (edge.attributes.driveableforward || edge.attributes.driveablereverse) {
         bundle.node.attributes_.non_link_edge = bundle.node.attributes_.non_link_edge || !edge.attributes.link;
+        bundle.node.attributes_.non_ferry_edge = bundle.node.attributes_.non_ferry_edge || !edge.attributes.ferry;
       }
       if (edge.attributes.link) {
         bundle.link_count++;
@@ -507,6 +514,122 @@ void ReclassifyLinks(const std::string& ways_file,
   LOG_INFO("Finished with " + std::to_string(count) + " reclassified.");
 }
 
+/**
+ * Get the best classification for any driveable non-ferry edges from a node.
+ * @param  edges The file backed list of edges in the graph.
+ * @return  Returns the best (most important) classification
+ */
+uint32_t GetBestNonFerryClass(const std::map<Edge, size_t>& edges) {
+  uint32_t bestrc = kAbsurdRoadClass;
+  for (const auto& edge : edges) {
+    if (!edge.first.attributes.ferry &&
+        (edge.first.attributes.driveableforward ||
+         edge.first.attributes.driveablereverse)) {
+      if (edge.first.attributes.importance < bestrc) {
+        bestrc = edge.first.attributes.importance;
+      }
+    }
+  }
+  return bestrc;
+}
+
+// Reclassify links (ramps and turn channels). OSM usually classifies links as
+// the best classification, while to more effectively create shortcuts it is
+// better to "downgrade" link edges to the lower classification.
+void ReclassifyFerryConnections(const std::string& ways_file,
+                     const std::string& nodes_file,
+                     const std::string& edges_file,
+                     const uint32_t rc,
+                     DataQuality& stats) {
+  LOG_INFO("Reclassifying ferry connection graph edges...")
+
+  uint32_t count = 0;
+  std::unordered_set<size_t> doneset;     // Nodes to which shortest path found
+  std::unordered_set<size_t> adjset;      // Set of nodes to expand
+  std::list<size_t> connedgeindexes;      // Edge indexes to reclassify
+  sequence<OSMWay> ways(ways_file, false);
+  sequence<Edge> edges(edges_file, false);
+  sequence<Node> nodes(nodes_file, false);
+
+ /*
+  // try to expand
+  auto expand = [&expandset, &endrc, &nodes, &edges, &visitedset] (const Edge& edge, const sequence<Node>::iterator& node_itr) {
+    auto end_node_itr = (edge.sourcenode_ == node_itr.position() ? nodes[edge.targetnode_] : node_itr);
+    auto end_node_bundle = collect_node_edges(end_node_itr, nodes, edges);
+
+    // Add the classification if there is a driveable non-link edge
+    if (end_node_bundle.node.attributes_.non_link_edge) {
+      endrc.insert(GetBestNonLinkClass(end_node_bundle.node_edges));
+      if (end_node_bundle.link_count > 1 &&
+          end_node_bundle.node.attributes_.shortlink &&
+          visitedset.find(end_node_itr.position()) == visitedset.end()) {
+       expandset.insert(end_node_itr.position());
+      }
+    } else if (visitedset.find(end_node_itr.position()) == visitedset.end()) {
+      expandset.insert(end_node_itr.position());
+    }
+  };
+*/
+  // Need to expand from the end of the ferry until we meet a road with primary
+  // classification. Want to do simple shortest path (time based only) and obey
+  // driveability. If the starting connection is oneway onto the ferry we need
+  // to check opposing driveability
+
+  // Iterate through nodes and find any that connect to both a ferry and a
+  // regular (non-ferry) edge
+  sequence<Node>::iterator node_itr = nodes.begin();
+  while (node_itr != nodes.end()) {
+    auto bundle = collect_node_edges(node_itr, nodes, edges);
+    if (bundle.node.attributes_.ferry_edge &&
+        bundle.node.attributes_.non_ferry_edge &&
+        GetBestNonFerryClass(bundle.node_edges) > rc) {
+
+      // Clear the adjacency set and done set
+      doneset = {};
+      adjset  = {};
+
+      // Add node to the adjacency set
+  //    adjset.insert()
+
+      // Expand edges until a node connected to specified road classification
+      // is reached
+      while (!adjset.empty()) {
+ //       expand(startedge.first, node_itr);
+
+
+        // Expand all edges from this node and pop from expand set
+        auto expand_node_itr = nodes[*adjset.begin()];
+        auto expanded = collect_node_edges(expand_node_itr, nodes, edges);
+        doneset.insert(expand_node_itr.position());
+        adjset.erase(adjset.begin());
+
+
+        for (const auto& expandededge : expanded.node_edges) {
+
+          // Expand from end node of this link edge
+   //       expand(expandededge.first, expand_node_itr);
+        }
+      }
+
+      // Trace shortest path backwards and upgrade classification on
+      // any edges below the specified classification.
+ /*     for (auto idx : linkedgeindexes) {
+        sequence<Edge>::iterator element = edges[idx];
+        auto edge = *element;
+        if (edge.attributes.importance > rc) {
+          edge.attributes.importance = rc;
+          element = edge;
+          count++;
+        }
+      } */
+    }
+
+    // Go to the next node
+    node_itr += bundle.node_count;
+  }
+  LOG_INFO("Finished. " + std::to_string(count) + " edges reclassified.");
+}
+
 /*
 struct DuplicateEdgeInfo {
   uint32_t edgeindex;
@@ -625,7 +748,6 @@ uint32_t CreateSimpleTurnRestriction(const uint64_t wayid, const size_t endnode,
 // Walk the shape and look for any empty tiles that the shape intersects
 void CheckForIntersectingTiles(const GraphId& tile1, const GraphId& tile2,
                 const Tiles& tiling, std::vector<PointLL>& shape,
-                const std::map<GraphId, size_t>& tiles,
                 DataQuality& stats) {
   // Walk the shape segments until we are outside
   uint32_t current_tile = tile1.tileid();
@@ -636,10 +758,7 @@ void CheckForIntersectingTiles(const GraphId& tile1, const GraphId& tile2,
     if (next_tile != current_tile) {
       // If a neighbor we can just add this tile
       if (tiling.AreNeighbors(current_tile, next_tile)) {
-        GraphId id(next_tile, 2, 0);
-        if (tiles.find(id) == tiles.end()) {
-          stats.AddIntersectedTile(id);
-        }
+        stats.AddIntersectedTile(GraphId(next_tile, 2, 0));
       } else {
         // Not a neighbor - find any intermediate intersecting tiles
 
@@ -650,12 +769,10 @@ void CheckForIntersectingTiles(const GraphId& tile1, const GraphId& tile2,
              row <= std::max(rc1.first, rc2.first); row++) {
           for (int32_t col = std::min(rc1.second, rc2.second);
                        col <= std::max(rc1.second, rc2.second); col++) {
-            // Get the tile Id for the row,col. Skip if either of the 2 tiles
-            // or if the tile is populated.
+            // Get the tile Id for the row,col. Skip if either of the 2 tiles.
             int32_t tileid = tiling.TileId(row, col);
             GraphId id(tileid, 2, 0);
-            if (tileid == current_tile || tileid == next_tile ||
-                tiles.find(id) != tiles.end()) {
+            if (tileid == current_tile || tileid == next_tile) {
               continue;
             }
 
@@ -677,7 +794,6 @@ void CheckForIntersectingTiles(const GraphId& tile1, const GraphId& tile2,
 void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_file,
     const std::string& nodes_file, const std::string& edges_file,
     const TileHierarchy& hierarchy, const OSMData& osmdata,
-    const std::map<GraphId, size_t>& tiles,
     std::map<GraphId, size_t>::const_iterator tile_start,
     std::map<GraphId, size_t>::const_iterator tile_end,
     std::promise<DataQuality>& result) {
@@ -834,7 +950,7 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
           GraphId tileid2 = (*nodes[target]).graph_id.Tile_Base();
           if (tileid1 != tileid2 && !tiling.AreNeighbors(tileid1, tileid2)) {
             CheckForIntersectingTiles(tileid1, tileid2, tiling,
-                     shape, tiles, stats);
+                     shape, stats);
           }
 
           // Increment the directed edge index within the tile
@@ -845,7 +961,7 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
         // Set the node lat,lng, index of the first outbound edge, and the
         // directed edge count from this edge and the best road class
         // from the node. Increment directed edge count.
-        NodeInfoBuilder nodebuilder(node_ll, directededgecount, n, bestclass, node.access_mask(),
+        NodeInfoBuilder nodebuilder(node_ll, bestclass, node.access_mask(),
                                     node.type(), (n == 1), node.traffic_signal());
 
         directededgecount += n;
@@ -911,7 +1027,7 @@ void BuildLocalTiles(const unsigned int thread_count, const OSMData& osmdata,
     threads[i].reset(
       new std::thread(BuildTileSet,  std::cref(ways_file), std::cref(way_nodes_file),
                       std::cref(nodes_file), std::cref(edges_file), std::cref(tile_hierarchy),
-                      std::cref(osmdata), std::cref(tiles), tile_start, tile_end,
+                      std::cref(osmdata), tile_start, tile_end,
                       std::ref(results[i]))
     );
   }
@@ -939,9 +1055,7 @@ void BuildLocalTiles(const unsigned int thread_count, const OSMData& osmdata,
 
   // Add "empty" tiles for any intersected tiles
   for (auto& empty_tile : stats.intersected_tiles) {
-    if (GraphReader::DoesTileExist(tile_hierarchy, empty_tile)) {
-      LOG_ERROR("Writing an empty tile over a valid tile!");
-    } else {
+    if (!GraphReader::DoesTileExist(tile_hierarchy, empty_tile)) {
       GraphTileBuilder graphtile;
       LOG_INFO("Add empty tile for: " + std::to_string(empty_tile.tileid()));
       graphtile.StoreTileData(tile_hierarchy, empty_tile);

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -106,8 +106,10 @@ GraphTileBuilder::GraphTileBuilder(const baldr::TileHierarchy& hierarchy,
   for (auto offset : edge_info_offsets) {
     // Verify the offsets match as we create the edge info builder list
     if (offset != edge_info_offset_) {
-      LOG_ERROR("offset = " + std::to_string(offset) + " ei offset= " +
-                std::to_string(edge_info_offset_));
+      LOG_ERROR("GraphTileBuilder TileID: " +
+            std::to_string(header_->graphid().tileid()) +
+            " offset stored in directed edge: = " + std::to_string(offset) +
+            " current ei offset= " + std::to_string(edge_info_offset_));
     }
     EdgeInfo ei(edgeinfo_ + offset, textlist_, textlist_size_);
     EdgeInfoBuilder eib;
@@ -406,15 +408,38 @@ void GraphTileBuilder::Update(const baldr::TileHierarchy& hierarchy,
 
 // Add a node and list of directed edges
 void GraphTileBuilder::AddNodeAndDirectedEdges(
-    const NodeInfoBuilder& node,
+    NodeInfoBuilder& node,
     const std::vector<DirectedEdgeBuilder>& directededges) {
-  // Add the node to the list
+  // Set the index to the first directed edge from this node and
+  // set its count. Add the node to the list
+  node.set_edge_index(directededges_builder_.size());
+  node.set_edge_count(directededges.size());
   nodes_builder_.push_back(node);
 
   // Add directed edges to the list
   for (const auto& directededge : directededges) {
     directededges_builder_.push_back(directededge);
   }
+}
+
+// Get the current list of node builders.
+const std::vector<NodeInfoBuilder>& GraphTileBuilder::nodes() const {
+  return nodes_builder_;
+}
+
+// Gets the current list of directed edge (builders).
+const std::vector<DirectedEdgeBuilder>& GraphTileBuilder::directededges() const {
+  return directededges_builder_;
+}
+
+// Clear the current list of nodes (builders).
+void GraphTileBuilder::ClearNodes() {
+  nodes_builder_.size();
+}
+
+// Clear the current list of directed edges (builders).
+void GraphTileBuilder::ClearDirectedEdges() {
+  directededges_builder_.clear();
 }
 
 // Add a transit departure.

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -434,7 +434,7 @@ const std::vector<DirectedEdgeBuilder>& GraphTileBuilder::directededges() const 
 
 // Clear the current list of nodes (builders).
 void GraphTileBuilder::ClearNodes() {
-  nodes_builder_.size();
+  nodes_builder_.clear();
 }
 
 // Clear the current list of directed edges (builders).
@@ -628,6 +628,13 @@ DirectedEdgeBuilder& GraphTileBuilder::directededge_builder(const size_t idx) {
 SignBuilder& GraphTileBuilder::sign(const size_t idx) {
   if (idx < header_->signcount())
     return static_cast<SignBuilder&>(signs_[idx]);
+  throw std::runtime_error("GraphTileBuilder sign index is out of bounds");
+}
+
+// Gets a sign builder at the specified index.
+SignBuilder& GraphTileBuilder::sign_builder(const size_t idx) {
+  if (idx < header_->signcount())
+    return signs_builder_[idx];
   throw std::runtime_error("GraphTileBuilder sign index is out of bounds");
 }
 

--- a/src/mjolnir/nodeinfobuilder.cc
+++ b/src/mjolnir/nodeinfobuilder.cc
@@ -33,8 +33,6 @@ NodeInfoBuilder::NodeInfoBuilder()
 }
 
 NodeInfoBuilder::NodeInfoBuilder(const std::pair<float, float>& ll,
-                                 const uint32_t edge_index,
-                                 const uint32_t edge_count,
                                  const RoadClass rc,
                                  const uint32_t access,
                                  const NodeType type,
@@ -42,8 +40,6 @@ NodeInfoBuilder::NodeInfoBuilder(const std::pair<float, float>& ll,
                                  const bool traffic_signal)
     : NodeInfo() {
   set_latlng(ll);
-  set_edge_index(edge_index);
-  set_edge_count(edge_count);
   set_bestrc(rc);
   set_access(access);
   set_type(type);

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -792,9 +792,7 @@ void AddOSMConnection(Stop& stop, const GraphTile* tile,
   }
 
   // TODO - more complete shape
-  std::vector<PointLL> shape;
-  shape.push_back(tile->node(startnode)->latlng());
-  shape.push_back(stop.ll);
+  std::vector<PointLL> shape{tile->node(startnode)->latlng(), stop.ll};
   float length = PointLL::Length(shape);
 
   // Add connection to start node
@@ -908,7 +906,7 @@ void build(const boost::property_tree::ptree& pt,
         }
       }
     }
-LOG_INFO("Connection Edges: size= " + std::to_string(connection_edges.size()));
+    LOG_INFO("Connection Edges: size= " + std::to_string(connection_edges.size()));
     std::sort(connection_edges.begin(), connection_edges.end());
 
     // Get the current number of directed edges. Add those needed for

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -100,14 +100,37 @@ class GraphTileBuilder : public baldr::GraphTile {
               const std::vector<SignBuilder>& signs);
 
   /**
-   * Add a node and its outbound edges.
+   * Add a node and its outbound edges. Sets the node's edge index
+   * and edge count.
    * @param  node   Node information builder.
    * @param  directededges  List of directed edges (builders) outbound
    *                        from the node.
    */
   void AddNodeAndDirectedEdges(
-      const NodeInfoBuilder& node,
+      NodeInfoBuilder& node,
       const std::vector<DirectedEdgeBuilder>& directededges);
+
+  /**
+   * Get the current list of node builders.
+   * @return  Returns the node info builders.
+   */
+  const std::vector<NodeInfoBuilder>& nodes() const;
+
+  /**
+   * Gets the current list of directed edge (builders).
+   * @return  Returns the directed edge builders.
+   */
+  const std::vector<DirectedEdgeBuilder>& directededges() const;
+
+  /**
+   * Clear the current list of nodes (builders).
+   */
+  void ClearNodes();
+
+  /**
+   * Clear the current list of directed edges (builders).
+   */
+  void ClearDirectedEdges();
 
   /**
    * Add a transit departure.

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -231,24 +231,28 @@ class GraphTileBuilder : public baldr::GraphTile {
   /**
    * Gets a builder for a node from an existing tile.
    * @param  idx  Index of the node within the tile.
+   * @return  Returns a reference to the node builder.
    */
   NodeInfoBuilder& node(const size_t idx);
 
   /**
    * Get the node builder at the specified index.
    * @param  idx  Index of the node builder.
+   * @return  Returns a reference to the node builder.
    */
   NodeInfoBuilder& node_builder(const size_t idx);
 
   /**
    * Gets a builder for a directed edge from existing tile data.
    * @param  idx  Index of the directed edge within the tile.
+   * @return  Returns a reference to the directed edge builder.
    */
   DirectedEdgeBuilder& directededge(const size_t idx);
 
   /**
    * Get the directed edge builder at the specified index.
    * @param  idx  Index of the directed edge builder.
+   * @return  Returns a reference to the directed edge builder.
    */
   DirectedEdgeBuilder& directededge_builder(const size_t idx);
 
@@ -256,8 +260,16 @@ class GraphTileBuilder : public baldr::GraphTile {
    * Gets a non-const sign (builder) from existing tile data.
    * @param  idx  Index of the sign (index in the array, not the
    *              directed edge index) within the tile.
+   * @return  Returns a reference to the sign builder.
    */
   SignBuilder& sign(const size_t idx);
+
+  /**
+   * Get the sign builder at the specified index.
+   * @param  idx  Index of the sign builder.
+   * @return  Returns a reference to the sign builder.
+   */
+  SignBuilder& sign_builder(const size_t idx);
 
   /**
    * Gets a const admin builder at specified index.

--- a/valhalla/mjolnir/nodeinfobuilder.h
+++ b/valhalla/mjolnir/nodeinfobuilder.h
@@ -26,8 +26,6 @@ class NodeInfoBuilder : public baldr::NodeInfo {
   /**
    * Constructor with arguments
    * @param  ll  Lat,lng position of the node.
-   * @param  edge_index     The GraphId of the first outbound edge.
-   * @param  edge_count     The number of outbound directed edges.
    * @param  rc             Best road class / importance of outbound edges.
    * @param  access         Access mask at this node.
    * @param  type           The type of node.
@@ -35,8 +33,7 @@ class NodeInfoBuilder : public baldr::NodeInfo {
    * @param  traffic_signal Has a traffic signal at this node?
    *
    */
-  NodeInfoBuilder(const std::pair<float, float>& ll, const uint32_t edge_index,
-                  const uint32_t edge_count, const baldr::RoadClass rc,
+  NodeInfoBuilder(const std::pair<float, float>& ll, const baldr::RoadClass rc,
                   const uint32_t access, const baldr::NodeType type,
                   const bool end, const bool traffic_signal);
 

--- a/valhalla/mjolnir/osmnode.h
+++ b/valhalla/mjolnir/osmnode.h
@@ -23,7 +23,9 @@ struct NodeAttributes {
   uint32_t non_link_edge    : 1;
   uint32_t link_edge        : 1;
   uint32_t shortlink        : 1;  // Link edge < kMaxInternalLength
-  uint32_t spare            : 3;
+  uint32_t non_ferry_edge   : 1;
+  uint32_t ferry_edge       : 1;
+  uint32_t spare            : 1;
 };
 
 /**


### PR DESCRIPTION
Data conversion with no errors for CA with BART transit DB present. Verified that regular routes work - next step is to validate and debug transit routing!

NOTE: stub for a method to reclassify edges that connect to ferries is in place but is incomplete and not actually used yet.