### PR TITLE
only ever open pbf files once

### DIFF
--- a/src/mjolnir/osmpbfparser.cc
+++ b/src/mjolnir/osmpbfparser.cc
@@ -232,14 +232,13 @@ Member::Member(const Relation::MemberType type, const uint64_t id, const std::st
 Member::Member(Member&& other): member_type(other.member_type), member_id(other.member_id), role(std::move(other.role)) {
 }
 
-void Parser::parse(const std::string& filename, const Interest interest, Callback& callback) {
+void Parser::parse(std::ifstream& file, const Interest interest, Callback& callback) {
   char* buffer = new char[MAX_UNCOMPRESSED_BLOB_SIZE];
   char* unpack_buffer = new char[MAX_UNCOMPRESSED_BLOB_SIZE];
 
-  //check if the file is open
-  std::ifstream file(filename, std::ios::binary);
-  if (!file.is_open())
-    throw std::runtime_error("Unable to open: " + filename);
+  //start from the top
+  file.clear();
+  file.seekg(0, std::ios::beg);
 
   //while there is more to read
   while (!file.eof()) {

--- a/src/mjolnir/pbfadminparser.cc
+++ b/src/mjolnir/pbfadminparser.cc
@@ -142,27 +142,34 @@ OSMData PBFAdminParser::Parse(const boost::property_tree::ptree& pt, const std::
   OSMData osmdata{};
   admin_callback callback(pt, osmdata);
 
+  LOG_INFO("Parsing files: " + boost::algorithm::join(input_files, ", "));
+
+  //hold open all the files so that if something else (like diff application)
+  //needs to mess with them we wont have troubles with inodes changing underneath us
+  std::list<std::ifstream> file_handles;
+  for (const auto& input_file : input_files) {
+    file_handles.emplace_back(input_file, std::ios::binary);
+    if (!file_handles.back().is_open())
+      throw std::runtime_error("Unable to open: " + input_file);
+  }
+
   // Parse each input file for relations
   LOG_INFO("Parsing relations...")
-  for (const auto& input_file : input_files) {
-    OSMPBF::Parser::parse(input_file, OSMPBF::Interest::RELATIONS, callback);
-  }
+  for (auto& file_handle : file_handles)
+    OSMPBF::Parser::parse(file_handle, OSMPBF::Interest::RELATIONS, callback);
   LOG_INFO("Finished with " + std::to_string(osmdata.admins_.size()) + " admin polygons comprised of " + std::to_string(osmdata.osm_way_count) + " ways");
-
 
   // Parse the ways.
   LOG_INFO("Parsing ways...");
-  for (const auto& input_file : input_files) {
-    OSMPBF::Parser::parse(input_file, OSMPBF::Interest::WAYS, callback);
-  }
+  for (auto& file_handle : file_handles)
+    OSMPBF::Parser::parse(file_handle, OSMPBF::Interest::WAYS, callback);
   LOG_INFO("Finished with " + std::to_string(osmdata.way_map.size()) + " ways comprised of " + std::to_string(osmdata.node_count) + " nodes");
 
   // Parse node in all the input files. Skip any that are not marked from
   // being used in a way.
   LOG_INFO("Parsing nodes...");
-  for (const auto& input_file : input_files) {
-    OSMPBF::Parser::parse(input_file, OSMPBF::Interest::NODES, callback);
-  }
+  for (auto& file_handle : file_handles)
+    OSMPBF::Parser::parse(file_handle, OSMPBF::Interest::NODES, callback);
   LOG_INFO("Finished with " + std::to_string(osmdata.osm_node_count) + " nodes");
 
   //done with pbf

--- a/valhalla/mjolnir/osmpbfparser.h
+++ b/valhalla/mjolnir/osmpbfparser.h
@@ -70,7 +70,7 @@ class Parser {
  public:
   Parser() = delete;
   //parse the pbf file for the things you are interested in
-  static void parse(const std::string& filename, const Interest interest, Callback& callback);
+  static void parse(std::ifstream& file, const Interest interest, Callback& callback);
   //clean up (mainly pbf memory)
   static void free();
 };


### PR DESCRIPTION
this has the advantage that we hold onto the inodes of the files at the beginning of the program so that if an update process makes new files it wont affect us. this may be why running updates in the background while cutting tiles is not working. tests all pass, cut data from an extract had the exact same size after this change.