### PR TITLE
New statistic class in GraphValidator

### DIFF
--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -19,7 +19,6 @@
 #include <future>
 #include <mutex>
 #include <numeric>
-#include <tuple>
 
 #include <valhalla/midgard/logging.h>
 #include <valhalla/midgard/pointll.h>
@@ -348,7 +347,7 @@ void validate(const boost::property_tree::ptree& hierarchy_properties,
       vStats.add_dup(dupcount, level);
     }
 
-    // Create return tuple and put into promise
+    // Fill promise with statistics
     result.set_value(vStats);
   }
 }

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -82,12 +82,12 @@ class validator_stats {
   std::map<std::string, std::map<RoadClass, float> > country_maps;
   std::set<uint32_t> tile_ids;
   std::set<std::string> iso_codes;
+
+public:
   const std::vector<RoadClass> rclasses = {RoadClass::kMotorway, RoadClass::kPrimary,
                                      RoadClass::kResidential, RoadClass::kSecondary,
                                      RoadClass::kServiceOther, RoadClass::kTertiary,
                                      RoadClass::kTrunk, RoadClass::kUnclassified};
-public:
-
 	validator_stats () : tile_maps(), country_maps(), iso_codes(), tile_ids() { }
 
 	void add_tile_road (const uint32_t& tile_id, const RoadClass& rclass, float length) {
@@ -416,8 +416,31 @@ namespace mjolnir {
       LOG_INFO("Average density = " + std::to_string(average_density) +
                " max = " + std::to_string(max_density));
     }
-
-    //TODO this is there the real statistics will happen.
+    bool log_stats = false;
+    if (log_stats) {
+      std::map<RoadClass, std::string> roadClassToString =
+        { {RoadClass::kMotorway, "Motorway"}, {RoadClass::kTrunk, "Trunk"}, {RoadClass::kPrimary, "Primary"},
+          {RoadClass::kSecondary, "Secondary"}, {RoadClass::kTertiary, "Tertiary"},
+          {RoadClass::kUnclassified, "Unclassified"},{RoadClass::kResidential, "Residential"},
+          {RoadClass::kServiceOther, "ServiceOther"}
+        };
+      auto country_maps = roadStats.get_country_maps();
+      for (auto country : roadStats.get_isos()) {
+        LOG_INFO("Country: " + country);
+        for (auto rclass : roadStats.rclasses) {
+          std::string roadStr = roadClassToString[rclass];
+          LOG_INFO((boost::format("   %1%: %2% Km") % roadStr % country_maps[country][rclass]).str());
+        }
+      }
+      auto tile_maps = roadStats.get_tile_maps();
+      for (auto tileid : roadStats.get_ids()) {
+        LOG_INFO("Tile: " + std::to_string(tileid));
+        for (auto rclass : roadStats.rclasses) {
+          std::string roadStr = roadClassToString[rclass];
+          LOG_INFO((boost::format("   %1%: %2% Km") % roadStr % tile_maps[tileid][rclass]).str());
+        }
+      }
+    }
   }
 }
 }

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -35,23 +35,41 @@ using namespace valhalla::mjolnir;
 
 namespace {
 
-class return_stats {
+class validator_stats {
+  std::map<int32_t, std::map<RoadClass, float> > tile_maps;
+  std::map<std::string, std::map<RoadClass, float> > country_maps;
+  std::set<uint32_t> tile_ids;
+  std::set<std::string> iso_codes;
   std::vector<std::vector<uint32_t> > dupcounts;
   std::vector<std::vector<float> > densities;
-
+  std::map<RoadClass, std::string> roadClassToString =
+    { {RoadClass::kMotorway, "Motorway"}, {RoadClass::kTrunk, "Trunk"}, {RoadClass::kPrimary, "Primary"},
+      {RoadClass::kSecondary, "Secondary"}, {RoadClass::kTertiary, "Tertiary"},
+      {RoadClass::kUnclassified, "Unclassified"},{RoadClass::kResidential, "Residential"},
+      {RoadClass::kServiceOther, "ServiceOther"}
+    };
+  std::vector<RoadClass> rclasses =
+    { RoadClass::kMotorway, RoadClass::kPrimary,
+      RoadClass::kResidential, RoadClass::kSecondary,
+      RoadClass::kServiceOther, RoadClass::kTertiary,
+      RoadClass::kTrunk, RoadClass::kUnclassified
+    };
 public:
 
-  return_stats () : dupcounts(3), densities(3) { }
+	validator_stats ()
+    : tile_maps(), country_maps(), iso_codes(), tile_ids(), dupcounts(3), densities(3) { }
 
-  std::vector<uint32_t> get_dups(int level) { return dupcounts[level]; }
+	void add_tile_road (const uint32_t& tile_id, const RoadClass& rclass, float length) {
+	  this->tile_ids.insert(tile_id);
+	  this->tile_maps[tile_id][rclass] += length;
+	}
 
-  std::vector<float> get_densities(int level) { return densities[level]; }
+	void add_country_road (const std::string& ctry_code, const RoadClass& rclass, float length) {
+	  this->iso_codes.insert(ctry_code);
+	  this->country_maps[ctry_code][rclass] += length;
+	}
 
-  std::vector<std::vector<uint32_t> > get_dups() { return dupcounts; }
-
-  std::vector<std::vector<float> > get_densities() { return densities; }
-
-  void add_density (float density, int level) {
+	void add_density (float density, int level) {
     this->densities[level].push_back(density);
   }
 
@@ -59,7 +77,37 @@ public:
     this->dupcounts[level].push_back(newdup);
   }
 
-  void add_stat (return_stats& stats) {
+	const std::set<uint32_t>& get_ids () const { return tile_ids; }
+
+	const std::set<std::string>& get_isos () const { return iso_codes; }
+
+	const std::map<int32_t, std::map<RoadClass, float> >& get_tile_maps () const { return tile_maps; }
+
+	const std::map<std::string, std::map<RoadClass, float> >& get_country_maps () const { return country_maps; }
+
+	const std::vector<uint32_t> get_dups(int level) const { return dupcounts[level]; }
+
+  const std::vector<float> get_densities(int level) const { return densities[level]; }
+
+  const std::vector<std::vector<uint32_t> > get_dups() const { return dupcounts; }
+
+  const std::vector<std::vector<float> > get_densities() const { return densities; }
+
+  void add (const validator_stats& stats) {
+    auto newTileMaps = stats.get_tile_maps();
+    auto newCountryMaps = stats.get_country_maps();
+    auto ids = stats.get_ids();
+    auto isos = stats.get_isos();
+    for (auto& id : ids) {
+      for (auto& rclass : this->rclasses) {
+        this->add_tile_road(id, rclass, newTileMaps[id][rclass]);
+      }
+    }
+    for (auto& iso : isos) {
+      for (auto& rclass : this->rclasses) {
+        this->add_country_road(iso, rclass, newCountryMaps[iso][rclass]);
+      }
+    }
     uint32_t level = 0;
     for (auto& dupvec : stats.get_dups()) {
       for (auto& dup : dupvec) {
@@ -75,55 +123,30 @@ public:
       level++;
     }
   }
-};
 
-class validator_stats {
-  std::map<int32_t, std::map<RoadClass, float> > tile_maps;
-  std::map<std::string, std::map<RoadClass, float> > country_maps;
-  std::set<uint32_t> tile_ids;
-  std::set<std::string> iso_codes;
+  void log_country_stats() {
+    // Print the Country statistics
+    for (auto country : this->iso_codes) {
+      LOG_DEBUG("Country: " + country);
+      for (auto rclass : this->rclasses) {
+        std::string roadStr = roadClassToString[rclass];
+        LOG_DEBUG((boost::format("   %1%: %2% Km")
+          % roadStr % this->country_maps[country][rclass]).str());
+      }
+    }
+  }
 
-public:
-  const std::vector<RoadClass> rclasses =
-    {RoadClass::kMotorway, RoadClass::kPrimary,
-     RoadClass::kResidential, RoadClass::kSecondary,
-     RoadClass::kServiceOther, RoadClass::kTertiary,
-     RoadClass::kTrunk, RoadClass::kUnclassified
-    };
-	validator_stats () : tile_maps(), country_maps(), iso_codes(), tile_ids() { }
-
-	void add_tile_road (const uint32_t& tile_id, const RoadClass& rclass, float length) {
-	  this->tile_ids.insert(tile_id);
-	  this->tile_maps[tile_id][rclass] += length;
-	}
-	void add_country_road (const std::string& ctry_code, const RoadClass& rclass, float length) {
-	  this->iso_codes.insert(ctry_code);
-	  this->country_maps[ctry_code][rclass] += length;
-	}
-	const std::set<uint32_t>& get_ids () const { return tile_ids; }
-
-	const std::set<std::string>& get_isos () const { return iso_codes; }
-
-	const std::map<int32_t, std::map<RoadClass, float> >& get_tile_maps () const { return tile_maps; }
-
-	const std::map<std::string, std::map<RoadClass, float> >& get_country_maps () const { return country_maps; }
-
-	void add (const validator_stats& stats) {
-	  auto newTileMaps = stats.get_tile_maps();
-	  auto newCountryMaps = stats.get_country_maps();
-	  auto ids = stats.get_ids();
-	  auto isos = stats.get_isos();
-	  for (auto& id : ids) {
-	    for (auto& rclass : this->rclasses) {
-	      this->add_tile_road(id, rclass, newTileMaps[id][rclass]);
-	    }
-	  }
-	  for (auto& iso : isos) {
-	    for (auto& rclass : this->rclasses) {
-	      this->add_country_road(iso, rclass, newCountryMaps[iso][rclass]);
-	    }
-	  }
-	}
+  void log_tile_stats() {
+    // Print the tile statistics
+    for (auto tileid : this->tile_ids) {
+      LOG_DEBUG("Tile: " + std::to_string(tileid));
+      for (auto rclass : this->rclasses) {
+        std::string roadStr = roadClassToString[rclass];
+        LOG_DEBUG((boost::format("   %1%: %2% Km")
+          % roadStr % this->tile_maps[tileid][rclass]).str());
+      }
+    }
+  }
 };
 
 // Get the GraphId of the opposing edge.
@@ -201,10 +224,9 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode, DirectedEdge& edge,
 
 void validate(const boost::property_tree::ptree& hierarchy_properties,
               std::queue<GraphId>& tilequeue, std::mutex& lock,
-              std::promise<std::tuple<return_stats, validator_stats> >& result) {
+              std::promise<validator_stats>& result) {
 
     // Our local class for gathering the stats
-    return_stats threadStat;
     validator_stats vStats;
     // Local Graphreader
     GraphReader graph_reader(hierarchy_properties);
@@ -309,7 +331,7 @@ void validate(const boost::property_tree::ptree& hierarchy_properties,
 
       // Add density to return class
       float density = (roadlength * 0.0005f) / tiles->Area(tileid);
-      threadStat.add_density(density, level);
+      vStats.add_density(density, level);
 
       // Write the new file
       lock.lock();
@@ -323,12 +345,11 @@ void validate(const boost::property_tree::ptree& hierarchy_properties,
       lock.unlock();
 
       // Add possible duplicates to return class
-      threadStat.add_dup(dupcount, level);
+      vStats.add_dup(dupcount, level);
     }
 
     // Create return tuple and put into promise
-    std::tuple<return_stats, validator_stats> statistics (threadStat, vStats);
-    result.set_value(statistics);
+    result.set_value(vStats);
   }
 }
 
@@ -350,7 +371,7 @@ namespace mjolnir {
                  pt.get<unsigned int>("concurrency",std::thread::hardware_concurrency())));
 
     // Setup promises
-    std::list<std::promise<std::tuple<return_stats, validator_stats> > > results;
+    std::list<std::promise<validator_stats> > results;
 
     // Create a randomized queue of tiles to work from
     const auto tile_hierarchy = reader.GetTileHierarchy();
@@ -386,15 +407,11 @@ namespace mjolnir {
     for (auto& thread : threads) {
       thread->join();
     }
-    // Get the returned objects out of the promise
-    return_stats stats;
-    validator_stats roadStats;
+    // Get the returned data from the promise
+    validator_stats stats;
     for (auto& result : results) {
       auto data = result.get_future().get();
-      auto returnData = std::get<0>(data);
-      stats.add_stat(returnData);
-      auto statsData = std::get<1>(data);
-      roadStats.add(statsData);
+      stats.add(data);
     }
     // Add up total dupcount_ and find densities
     LOG_INFO("Validation of signs and connectivity is done");
@@ -417,35 +434,8 @@ namespace mjolnir {
       LOG_INFO("Average density = " + std::to_string(average_density) +
                " max = " + std::to_string(max_density));
     }
-    // Whether or not to print ALL the stats
-    bool log_stats = false;
-    if (log_stats) {
-      // Map to help print the roadway classifications
-      std::map<RoadClass, std::string> roadClassToString =
-        { {RoadClass::kMotorway, "Motorway"}, {RoadClass::kTrunk, "Trunk"}, {RoadClass::kPrimary, "Primary"},
-          {RoadClass::kSecondary, "Secondary"}, {RoadClass::kTertiary, "Tertiary"},
-          {RoadClass::kUnclassified, "Unclassified"},{RoadClass::kResidential, "Residential"},
-          {RoadClass::kServiceOther, "ServiceOther"}
-        };
-      // Print the Country statistics
-      auto country_maps = roadStats.get_country_maps();
-      for (auto country : roadStats.get_isos()) {
-        LOG_INFO("Country: " + country);
-        for (auto rclass : roadStats.rclasses) {
-          std::string roadStr = roadClassToString[rclass];
-          LOG_INFO((boost::format("   %1%: %2% Km") % roadStr % country_maps[country][rclass]).str());
-        }
-      }
-      // Print the tile statistics
-      auto tile_maps = roadStats.get_tile_maps();
-      for (auto tileid : roadStats.get_ids()) {
-        LOG_INFO("Tile: " + std::to_string(tileid));
-        for (auto rclass : roadStats.rclasses) {
-          std::string roadStr = roadClassToString[rclass];
-          LOG_INFO((boost::format("   %1%: %2% Km") % roadStr % tile_maps[tileid][rclass]).str());
-        }
-      }
-    }
+    stats.log_country_stats();
+    stats.log_tile_stats();
   }
 }
 }

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -296,8 +296,8 @@ void validate(const boost::property_tree::ptree& hierarchy_properties,
           // Add road lengths to statistics class for current country and current tile
           if (validLength) {
             auto rclass = directededge.classification();
-            vStats.add_country_road(begin_node_iso, rclass, tempLength);
-            vStats.add_tile_road(tileid, rclass, tempLength);
+            vStats.add_country_road(begin_node_iso, rclass, tempLength / 2);
+            vStats.add_tile_road(tileid, rclass, tempLength / 2);
           }
         }
         // Add the node to the list
@@ -383,7 +383,7 @@ namespace mjolnir {
     for (auto& thread : threads) {
       thread->join();
     }
-    // Add up total dupcount_ and find densities
+    // Get the returned objects out of the promise
     return_stats stats;
     validator_stats roadStats;
     for (auto& result : results) {
@@ -393,7 +393,7 @@ namespace mjolnir {
       auto statsData = std::get<1>(data);
       roadStats.add(statsData);
     }
-
+    // Add up total dupcount_ and find densities
     LOG_INFO("Validation of signs and connectivity is done");
     for (uint8_t level = 0; level <= 2; level++) {
       // Print duplicates info for level

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -293,11 +293,14 @@ void validate(const boost::property_tree::ptree& hierarchy_properties,
               begin_node_iso != end_node_iso)
             directededge.set_ctry_crossing(true);
           directededges.emplace_back(std::move(directededge));
+
           // Add road lengths to statistics class for current country and current tile
           if (validLength) {
             auto rclass = directededge.classification();
-            vStats.add_country_road(begin_node_iso, rclass, tempLength / 2);
-            vStats.add_tile_road(tileid, rclass, tempLength / 2);
+            auto endnodeid = directededge.endnode().tileid();
+            uint8_t modifier = (tileid == endnodeid) ? 2 : 4;
+            vStats.add_country_road(begin_node_iso, rclass, tempLength / modifier);
+            vStats.add_tile_road(tileid, rclass, tempLength / modifier);
           }
         }
         // Add the node to the list

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -415,7 +415,7 @@ namespace mjolnir {
                " max = " + std::to_string(max_density));
     }
     // Whether or not to print ALL the stats
-    bool log_stats = true;
+    bool log_stats = false;
     if (log_stats) {
       // Map to help print the roadway classifications
       std::map<RoadClass, std::string> roadClassToString =


### PR DESCRIPTION
This class gathers statistics on the road lengths within tile and country boundaries. It collects the total road lengths for each road classification broken down by the tile ID and by the country ISO code. The statistics are logged to debug by default and the logging is part of the class. The class was also modified to handle the statistics of the tile levels that is output at the end of graph validation.

Some sample log output:
`2015/06/17 17:08:49.867722 [INFO] Country: US`
`2015/06/17 17:08:49.867740 [INFO]    Motorway: 3.00719e+07 Km`
`2015/06/17 17:08:49.867750 [INFO]    Primary: 2.75015e+07 Km`
`2015/06/17 17:08:49.867758 [INFO]    Residential: 1.85354e+08 Km`
`2015/06/17 17:08:49.867767 [INFO]    Secondary: 3.83092e+07 Km`
`2015/06/17 17:08:49.867774 [INFO]    ServiceOther: 2.53372e+07 Km`
`2015/06/17 17:08:49.867783 [INFO]    Tertiary: 3.95037e+07 Km`
`2015/06/17 17:08:49.867790 [INFO]    Trunk: 9.35517e+06 Km`
`2015/06/17 17:08:49.867799 [INFO]    Unclassified: 5.24041e+06 Km`

`2015/06/17 17:08:49.873237 [INFO] Tile: 749211`
`2015/06/17 17:08:49.873243 [INFO]    Motorway: 83180.5 Km`
`2015/06/17 17:08:49.873249 [INFO]    Primary: 42816.5 Km`
`2015/06/17 17:08:49.873256 [INFO]    Residential: 1.18913e+06 Km`
`2015/06/17 17:08:49.873263 [INFO]    Secondary: 124380 Km`
`2015/06/17 17:08:49.873269 [INFO]    ServiceOther: 126856 Km`
`2015/06/17 17:08:49.873276 [INFO]    Tertiary: 173731 Km`
`2015/06/17 17:08:49.873283 [INFO]    Trunk: 69589.8 Km`
`2015/06/17 17:08:49.873289 [INFO]    Unclassified: 22846.5 Km`

*The tile and country attributes are indented in the actual log*