### PR TITLE
ReclassifyFerryConnections

### DIFF
--- a/valhalla/mjolnir/osmnode.h
+++ b/valhalla/mjolnir/osmnode.h
@@ -25,7 +25,7 @@ struct NodeAttributes {
   uint32_t shortlink        : 1;  // Link edge < kMaxInternalLength
   uint32_t non_ferry_edge   : 1;
   uint32_t ferry_edge       : 1;
-  uint32_t spare            : 1;
+  uint32_t spare            : 9;
 };
 
 /**


### PR DESCRIPTION
Reclassifiies edges so we get a highway path from roads to the ferry. Computes shortest path and considers driveability (to or from the ferry). Short ferries are skipped - they are likely to be river crossings where bridges are likely to be better alternatives.  Adds only 1-2 minutes to planet processing.

This fixes the Vancouver/Victoria ferry case and English Channel crossings (though not all have been tested).