### PR TITLE
Clang compatibility fixes

### DIFF
--- a/src/mjolnir/dataquality.cc
+++ b/src/mjolnir/dataquality.cc
@@ -1,5 +1,6 @@
 #include "mjolnir/dataquality.h"
 #include <fstream>
+#include <vector>
 
 using namespace valhalla::midgard;
 using namespace valhalla::baldr;

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -96,7 +96,6 @@ std::map<GraphId, size_t> SortGraph(const std::string& nodes_file,
       //next node
       last_node = node;
       ++node_index;
-      return node;
     }
   );
 
@@ -353,7 +352,7 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
     std::map<GraphId, size_t>::const_iterator tile_end,
     std::promise<DataQuality>& result) {
 
-  std::string thread_id = static_cast<std::ostringstream&>(std::ostringstream() << std::this_thread::get_id()).str();
+  std::string thread_id = static_cast<const std::ostringstream&>(std::ostringstream() << std::this_thread::get_id()).str();
   LOG_INFO("Thread " + thread_id + " started");
 
   sequence<OSMWay> ways(ways_file, false);


### PR DESCRIPTION
For the reference, the reported errors were:

```
/Applications/Xcode.app/Contents/Developer/usr/bin/make  all-am
  CXX      src/mjolnir/libvalhalla_mjolnir_la-dataquality.lo
src/mjolnir/dataquality.cc:81:8: error: no member named 'vector' in namespace 'std'
  std::vector<DuplicateWay> dups;
```

```
src/mjolnir/graphbuilder.cc:65:5: error: no viable conversion from '(lambda at src/mjolnir/graphbuilder.cc:65:5)' to
      'const std::function<void (Node &)>'
    [&nodes, &edges, &run_index, &node_index, &node_count, &last_node, &tiles](Node& node) {
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1448:5: note: candidate
      constructor not viable: no known conversion from '(lambda at src/mjolnir/graphbuilder.cc:65:5)' to 'nullptr_t' for 1st argument
    function(nullptr_t) _NOEXCEPT : __f_(0) {}
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1449:5: note: candidate
      constructor not viable: no known conversion from '(lambda at src/mjolnir/graphbuilder.cc:65:5)' to 'const std::__1::function<void
      (valhalla::mjolnir::Node &)> &' for 1st argument
    function(const function&);
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1450:5: note: candidate
      constructor not viable: no known conversion from '(lambda at src/mjolnir/graphbuilder.cc:65:5)' to 'std::__1::function<void
      (valhalla::mjolnir::Node &)> &&' for 1st argument
    function(function&&) _NOEXCEPT;
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1454:41: note: candidate
      template ignored: disabled by 'enable_if' [with _Fp = (lambda at src/mjolnir/graphbuilder.cc:65:5)]
                                        __callable<_Fp>::value &&
                                        ^
./valhalla/mjolnir/sequence.h:108:50: note: passing argument to parameter 'predicate' here
  void transform(const std::function<void (T&)>& predicate) {
                                                 ^
```

```
src/mjolnir/graphbuilder.cc:356:27: error: non-const lvalue reference to type 'basic_ostringstream<[3 * ...]>' cannot bind to a temporary of
      type 'basic_ostringstream<[3 * ...]>'
  std::string thread_id = static_cast<std::ostringstream&>(std::ostringstream() << std::this_thread::get_id()).str();
                          ^                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```