### PR TITLE
Second update to statistic gathering

### DIFF
--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -204,8 +204,8 @@ void validate(const boost::property_tree::ptree& hierarchy_properties,
             auto rclass = directededge.classification();
             tempLength /= (tileid == directededge.endnode().tileid()) ? 2 : 4;
             //Determine access for directed edge
-            auto fward = ((0x1 & directededge.forwardaccess()) == 0x1);
-            auto bward = ((0x1 & directededge.reverseaccess()) == 0x1);
+            auto fward = ((kAutoAccess & directededge.forwardaccess()) == kAutoAccess);
+            auto bward = ((kAutoAccess & directededge.reverseaccess()) == kAutoAccess);
             // Check if one way
             if ((!fward || !bward) && (fward || bward)) {
               vStats.add_tile_one_way(tileid, rclass, tempLength);

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -32,8 +32,6 @@ using namespace valhalla::mjolnir;
 
 namespace {
 
-
-
 // Get the GraphId of the opposing edge.
 uint32_t GetOpposingEdgeIndex(const GraphId& startnode, DirectedEdge& edge,
                               GraphReader& graphreader_, uint32_t& dupcount_, std::string& endnodeiso_, std::mutex& lock) {
@@ -201,11 +199,33 @@ void validate(const boost::property_tree::ptree& hierarchy_properties,
             directededge.set_ctry_crossing(true);
           directededges.emplace_back(std::move(directededge));
 
-          // Add road lengths to statistics class for current country and current tile
-          if (validLength) {
+          // Only consider edge if edge is good and it's not a link
+          if (validLength && !directededge.link()) {
             auto rclass = directededge.classification();
-            auto endnodeid = directededge.endnode().tileid();
-            tempLength /= (tileid == endnodeid) ? 2 : 4;
+            tempLength /= (tileid == directededge.endnode().tileid()) ? 2 : 4;
+            //Determine access for directed edge
+            auto fward = ((0x1 & directededge.forwardaccess()) == 0x1);
+            auto bward = ((0x1 & directededge.reverseaccess()) == 0x1);
+            // Check if one way
+            if ((!fward || !bward) && (fward || bward)) {
+              vStats.add_tile_one_way(tileid, rclass, tempLength);
+              vStats.add_country_one_way(begin_node_iso, rclass, tempLength);
+            }
+            // Check if this edge is internal
+            if (directededge.internal()) {
+              vStats.add_tile_int_edge(tileid, rclass);
+              vStats.add_country_int_edge(begin_node_iso, rclass);
+            }
+            // Check if edge has maxspeed tag
+            if (directededge.speed_type() == SpeedType::kTagged){
+              vStats.add_tile_speed_info(tileid, rclass, tempLength);
+              vStats.add_country_speed_info(begin_node_iso, rclass, tempLength);
+            }
+            if (tilebuilder.edgeinfo(directededge.edgeinfo_offset())->name_count() > 0) {
+              vStats.add_tile_named(tileid, rclass, tempLength);
+              vStats.add_country_named(begin_node_iso, rclass, tempLength);
+            }
+            // Add road lengths to statistics for current country and tile
             vStats.add_country_road(begin_node_iso, rclass, tempLength);
             vStats.add_tile_road(tileid, rclass, tempLength);
           }
@@ -219,8 +239,9 @@ void validate(const boost::property_tree::ptree& hierarchy_properties,
       float density = (roadlength * 0.0005f) / area;
       vStats.add_density(density, level);
       vStats.add_tile_area(tileid, area);
+      vStats.add_tile_geom(tileid, tiles->TileBounds(tileid));
 
-      // Write the new file
+      // Write the new tile
       lock.lock();
       tilebuilder.Update(tile_hierarchy, hdrbuilder, nodes, directededges);
       lock.unlock();
@@ -279,7 +300,7 @@ namespace mjolnir {
     LOG_INFO("Done creating queue of tiles: count = " +
              std::to_string(tilequeue.size()));
 
-    // An atomic object we can use to do the synchronization
+    // An mutex we can use to do the synchronization
     std::mutex lock;
 
     LOG_INFO("GraphValidator - Validating signs and connectivity");
@@ -321,8 +342,6 @@ namespace mjolnir {
       LOG_INFO("Average density = " + std::to_string(average_density) +
                " max = " + std::to_string(max_density));
     }
-    stats.log_country_stats();
-    stats.log_tile_stats();
     stats.build_db(pt);
   }
 }

--- a/src/mjolnir/statistics.cc
+++ b/src/mjolnir/statistics.cc
@@ -354,7 +354,7 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
     ++index;
     // Individual Road Class Lengths
     for (auto rclass : rclasses) {
-      std::string roadStr = roadClassToString[rclass];
+      std::string roadStr = roadClassToString.at(rclass);
       sqlite3_bind_double(stmt, index, tile_lengths[tileid][rclass]);
       ++index;
     }
@@ -418,7 +418,7 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
       sqlite3_bind_int(stmt, index, tileid);
       ++index;
       // Roadway type
-      auto type = roadClassToString[rclass];
+      auto type = roadClassToString.at(rclass);
       sqlite3_bind_text(stmt, index, type.c_str(), type.length(), SQLITE_STATIC);
       ++index;
       // One Way data
@@ -476,7 +476,7 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
     ++index;
     // Individual Road Class Lengths
     for (auto rclass : rclasses) {
-      std::string roadStr = roadClassToString[rclass];
+      std::string roadStr = roadClassToString.at(rclass);
       sqlite3_bind_double(stmt, index, country_lengths[country][rclass]);
       ++index;
     }
@@ -524,7 +524,7 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
       sqlite3_bind_text(stmt, index, country.c_str(), country.length(), SQLITE_STATIC);
       ++index;
       // Roadway type
-      auto type = roadClassToString[rclass];
+      auto type = roadClassToString.at(rclass);
       sqlite3_bind_text(stmt, index, type.c_str(), type.length(), SQLITE_STATIC);
       ++index;
       // One Way data

--- a/src/mjolnir/statistics.cc
+++ b/src/mjolnir/statistics.cc
@@ -4,17 +4,20 @@
 #include "mjolnir/graphtilebuilder.h"
 
 #include <ostream>
-#include <set>
 #include <boost/format.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <sqlite3.h>
+#include <spatialite.h>
 #include <sstream>
 #include <iostream>
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_set>
+#include <unordered_map>
 
+#include "valhalla/midgard/aabb2.h"
 #include <valhalla/midgard/logging.h>
 #include <valhalla/baldr/tilehierarchy.h>
 #include <valhalla/baldr/graphid.h>
@@ -28,20 +31,59 @@ namespace valhalla {
 namespace mjolnir {
 
 validator_stats::validator_stats ()
-  : tile_maps(), tile_areas(), country_maps(), iso_codes(), tile_ids(), dupcounts(3), densities(3) { }
+  : tile_lengths(), country_lengths(), tile_int_edges(),country_int_edges(),
+    tile_one_way(), country_one_way(), tile_speed_info(), country_speed_info(),
+    tile_named(), country_named(), tile_areas(), tile_geometries(),
+    iso_codes(), tile_ids(), dupcounts(3), densities(3) { }
 
 void validator_stats::add_tile_road (const uint32_t& tile_id, const RoadClass& rclass, float length) {
   tile_ids.insert(tile_id);
-  tile_maps[tile_id][rclass] += length;
+  tile_lengths[tile_id][rclass] += length;
+}
+
+void validator_stats::add_country_road (const std::string& ctry_code, const RoadClass& rclass, float length) {
+  iso_codes.insert(ctry_code);
+  country_lengths[ctry_code][rclass] += length;
+}
+
+void validator_stats::add_tile_int_edge (const uint32_t& tile_id, const RoadClass& rclass, const uint32_t& count) {
+  tile_int_edges[tile_id][rclass] += count;
+}
+
+void validator_stats::add_country_int_edge (const std::string& ctry_code, const RoadClass& rclass, const uint32_t& count) {
+  country_int_edges[ctry_code][rclass] += count;
+}
+
+void validator_stats::add_tile_one_way (const uint32_t& tile_id, const RoadClass& rclass, float length) {
+  tile_one_way[tile_id][rclass] += length;
+}
+
+void validator_stats::add_country_one_way (const std::string& ctry_code, const RoadClass& rclass, float length) {
+  country_one_way[ctry_code][rclass] += length;
+}
+
+void validator_stats::add_tile_speed_info (const uint32_t& tile_id, const RoadClass& rclass, float length) {
+  tile_speed_info[tile_id][rclass] += length;
+}
+
+void validator_stats::add_country_speed_info (const std::string& ctry_code, const RoadClass& rclass, float length) {
+  country_speed_info[ctry_code][rclass] += length;
+}
+
+void validator_stats::add_tile_named (const uint32_t& tile_id, const RoadClass& rclass, float length) {
+  tile_named[tile_id][rclass] += length;
+}
+
+void validator_stats::add_country_named (const std::string& ctry_code, const RoadClass& rclass, float length) {
+  country_named[ctry_code][rclass] += length;
 }
 
 void validator_stats::add_tile_area (const uint32_t& tile_id, const float area) {
   tile_areas[tile_id] = area;
 }
 
-void validator_stats::add_country_road (const std::string& ctry_code, const RoadClass& rclass, float length) {
-  iso_codes.insert(ctry_code);
-  country_maps[ctry_code][rclass] += length;
+void validator_stats::add_tile_geom (const uint32_t& tile_id, const AABB2 geom) {
+  tile_geometries[tile_id] = geom;
 }
 
 void validator_stats::add_density (float density, int level) {
@@ -52,15 +94,33 @@ void validator_stats::add_dup (uint32_t newdup, int level) {
   dupcounts[level].push_back(newdup);
 }
 
-const std::set<uint32_t>& validator_stats::get_ids () const { return tile_ids; }
+const std::unordered_set<uint32_t>& validator_stats::get_ids () const { return tile_ids; }
 
-const std::set<std::string>& validator_stats::get_isos () const { return iso_codes; }
+const std::unordered_set<std::string>& validator_stats::get_isos () const { return iso_codes; }
 
-const std::map<uint32_t, std::map<RoadClass, float> >& validator_stats::get_tile_maps () const { return tile_maps; }
+const std::unordered_map<uint32_t, std::unordered_map<RoadClass, float, validator_stats::rclassHasher> >& validator_stats::get_tile_lengths () const { return tile_lengths; }
 
-const std::map<uint32_t, float>& validator_stats::get_tile_areas() const { return tile_areas; }
+const std::unordered_map<std::string, std::unordered_map<RoadClass, float, validator_stats::rclassHasher> >& validator_stats::get_country_lengths () const { return country_lengths; }
 
-const std::map<std::string, std::map<RoadClass, float> >& validator_stats::get_country_maps () const { return country_maps; }
+const std::unordered_map<uint32_t, std::unordered_map<RoadClass, uint32_t, validator_stats::rclassHasher> >& validator_stats::get_tile_int_edges () const { return tile_int_edges; }
+
+const std::unordered_map<std::string, std::unordered_map<RoadClass, uint32_t, validator_stats::rclassHasher> >& validator_stats::get_country_int_edges () const { return country_int_edges; }
+
+const std::unordered_map<uint32_t, std::unordered_map<RoadClass, float, validator_stats::rclassHasher> >& validator_stats::get_tile_one_way () const { return tile_one_way; }
+
+const std::unordered_map<std::string, std::unordered_map<RoadClass, float, validator_stats::rclassHasher> >& validator_stats::get_country_one_way () const { return country_one_way; }
+
+const std::unordered_map<uint32_t, std::unordered_map<RoadClass, float, validator_stats::rclassHasher> >& validator_stats::get_tile_speed_info () const { return tile_speed_info; }
+
+const std::unordered_map<std::string, std::unordered_map<RoadClass, float, validator_stats::rclassHasher> >& validator_stats::get_country_speed_info () const { return country_speed_info; }
+
+const std::unordered_map<uint32_t, std::unordered_map<RoadClass, float, validator_stats::rclassHasher> >& validator_stats::get_tile_named () const { return tile_named; }
+
+const std::unordered_map<std::string, std::unordered_map<RoadClass, float, validator_stats::rclassHasher> >& validator_stats::get_country_named () const { return country_named; }
+
+const std::unordered_map<uint32_t, float>& validator_stats::get_tile_areas() const { return tile_areas; }
+
+const std::unordered_map<uint32_t, AABB2>& validator_stats::get_tile_geometries() const { return tile_geometries; }
 
 const std::vector<uint32_t> validator_stats::get_dups(int level) const { return dupcounts[level]; }
 
@@ -71,20 +131,38 @@ const std::vector<std::vector<uint32_t> > validator_stats::get_dups() const { re
 const std::vector<std::vector<float> > validator_stats::get_densities() const { return densities; }
 
 void validator_stats::add (const validator_stats& stats) {
-  auto newTileMaps = stats.get_tile_maps();
+  auto newTileLengths = stats.get_tile_lengths();
   auto newTileAreas = stats.get_tile_areas();
-  auto newCountryMaps = stats.get_country_maps();
+  auto newTileGeom = stats.get_tile_geometries();
+  auto newTileOneWay = stats.get_tile_one_way();
+  auto newTileSpeed = stats.get_tile_speed_info();
+  auto newTileIntEdges = stats.get_tile_int_edges();
+  auto newTileNamed = stats.get_tile_named();
   auto ids = stats.get_ids();
   auto isos = stats.get_isos();
   for (auto& id : ids) {
+    add_tile_area(id, newTileAreas[id]);
+    add_tile_geom(id, newTileGeom[id]);
     for (auto& rclass : rclasses) {
-      add_tile_road(id, rclass, newTileMaps[id][rclass]);
-      add_tile_area(id, newTileAreas[id]);
+      add_tile_road(id, rclass, newTileLengths[id][rclass]);
+      add_tile_one_way(id, rclass, newTileOneWay[id][rclass]);
+      add_tile_speed_info(id, rclass, newTileSpeed[id][rclass]);
+      add_tile_int_edge(id, rclass, newTileIntEdges[id][rclass]);
+      add_tile_named(id, rclass, newTileNamed[id][rclass]);
     }
   }
+  auto newCountryLengths = stats.get_country_lengths();
+  auto newCountryOneWay = stats.get_country_one_way();
+  auto newCountrySpeed = stats.get_country_speed_info();
+  auto newCountryIntEdges = stats.get_country_int_edges();
+  auto newCountryNamed = stats.get_country_named();
   for (auto& iso : isos) {
     for (auto& rclass : rclasses) {
-      add_country_road(iso, rclass, newCountryMaps[iso][rclass]);
+      add_country_road(iso, rclass, newCountryLengths[iso][rclass]);
+      add_country_one_way(iso, rclass, newCountryOneWay[iso][rclass]);
+      add_country_speed_info(iso, rclass, newCountrySpeed[iso][rclass]);
+      add_country_int_edge(iso, rclass, newCountryIntEdges[iso][rclass]);
+      add_country_named(iso, rclass, newCountryNamed[iso][rclass]);
     }
   }
   uint32_t level = 0;
@@ -101,31 +179,7 @@ void validator_stats::add (const validator_stats& stats) {
     }
     level++;
   }
-}
 
-void validator_stats::log_country_stats() {
-  // Print the Country statistics
-  for (auto country : iso_codes) {
-    LOG_DEBUG("Country: " + country);
-    for (auto rclass : rclasses) {
-      std::string roadStr = roadClassToString[rclass];
-      LOG_DEBUG((boost::format("   %1%: %2% Km")
-        % roadStr % country_maps[country][rclass]).str());
-    }
-  }
-}
-
-void validator_stats::log_tile_stats() {
-  // Print the tile statistics
-  for (auto tileid : tile_ids) {
-    LOG_DEBUG("Tile: " + std::to_string(tileid));
-    LOG_DEBUG((boost::format("    Tile Area: %1% sq. Km") % tile_areas[tileid]).str());
-    for (auto rclass : rclasses) {
-      std::string roadStr = roadClassToString[rclass];
-      LOG_DEBUG((boost::format("    %1%: %2% Km")
-        % roadStr % tile_maps[tileid][rclass]).str());
-    }
-  }
 }
 
 void validator_stats::build_db(const boost::property_tree::ptree& pt) {
@@ -137,6 +191,8 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
   if (boost::filesystem::exists(database)) {
     boost::filesystem::remove(database);
   }
+
+  spatialite_init(0);
 
   sqlite3 *db_handle;
   sqlite3_stmt *stmt;
@@ -152,10 +208,32 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
     return;
   }
 
+  // loading SpatiaLite as an extension
+  sqlite3_enable_load_extension(db_handle, 1);
+  sql = "SELECT load_extension('libspatialite.so')";
+  ret = sqlite3_exec(db_handle, sql.c_str(), NULL, NULL, &err_msg);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("load_extension() error: " + std::string(err_msg));
+    sqlite3_free(err_msg);
+    sqlite3_close(db_handle);
+    return;
+  }
+  LOG_INFO("SpatiaLite loaded as an extension");
+
+  // Turn on foreign keys
+  sql = "PRAGMA foreign_keys = ON";
+  ret = sqlite3_exec(db_handle, sql.c_str(), NULL, NULL, &err_msg);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("Error: " + std::string(err_msg));
+    sqlite3_free(err_msg);
+    sqlite3_close(db_handle);
+    return;
+  }
   // Create table for tiles
-  sql = "CREATE TABLE tiledata (";
-  sql += "tileid INTEGER,";
+  sql = "SELECT InitSpatialMetaData(); CREATE TABLE tiledata (";
+  sql += "tileid INTEGER PRIMARY KEY,";
   sql += "tilearea REAL,";
+  sql += "totalroadlen REAL,";
   sql += "motorway REAL,";
   sql += "trunk REAL,";
   sql += "pmary REAL,";
@@ -172,9 +250,37 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
     sqlite3_close(db_handle);
     return;
   }
+  // Add tile geometry column
+  sql = "SELECT AddGeometryColumn('tiledata', ";
+  sql += "'geom', 4326, 'POLYGON', 2)";
+  ret = sqlite3_exec(db_handle, sql.c_str(), NULL, NULL, &err_msg);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("Error: " + std::string(err_msg));
+    sqlite3_free(err_msg);
+    sqlite3_close(db_handle);
+    return;
+  }
+  // Create table for tile data of road classes
+  sql = "CREATE TABLE rclasstiledata (";
+  sql += "tileid INTEGER,";
+  sql += "type TEXT NOT NULL,";
+  sql += "oneway REAL,";
+  sql += "maxspeed REAL,";
+  sql += "internaledges INTEGER,";
+  sql += "named REAL,";
+  sql += "FOREIGN KEY (tileid) REFERENCES tiledata(tileid)";
+  sql += ")";
+  ret = sqlite3_exec(db_handle, sql.c_str(), NULL, NULL, &err_msg);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("Error: " + std::string(err_msg));
+    sqlite3_free(err_msg);
+    sqlite3_close(db_handle);
+    return;
+  }
+
   // Create table for countries
   sql = "CREATE TABLE countrydata (";
-  sql += "isocode TEXT,";
+  sql += "isocode TEXT PRIMARY KEY,";
   sql += "motorway REAL,";
   sql += "trunk REAL,";
   sql += "pmary REAL,";
@@ -191,6 +297,25 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
     sqlite3_close(db_handle);
     return;
   }
+
+  // Create table for country data of road classes
+  sql = "CREATE TABLE rclassctrydata (";
+  sql += "isocode TEXT NOT NULL,";
+  sql += "type TEXT NOT NULL,";
+  sql += "oneway REAL,";
+  sql += "maxspeed REAL,";
+  sql += "internaledges INTEGER,";
+  sql += "named REAL,";
+  sql += "FOREIGN KEY (isocode) REFERENCES countrydata(isocode)";
+  sql += ")";
+  ret = sqlite3_exec(db_handle, sql.c_str(), NULL, NULL, &err_msg);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("Error: " + std::string(err_msg));
+    sqlite3_free(err_msg);
+    sqlite3_close(db_handle);
+    return;
+  }
+
   // Begin the prepared statements for tiledata
   ret = sqlite3_exec(db_handle, "BEGIN", NULL, NULL, &err_msg);
   if (ret != SQLITE_OK) {
@@ -199,8 +324,8 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
     sqlite3_close(db_handle);
     return;
   }
-  sql = "INSERT INTO tiledata (tileid, tilearea, motorway, trunk, pmary, secondary, tertiary, unclassified, residential, serviceother) ";
-  sql += "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+  sql = "INSERT INTO tiledata (tileid, tilearea, totalroadlen, motorway, trunk, pmary, secondary, tertiary, unclassified, residential, serviceother, geom) ";
+  sql += "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, GeomFromText(?, 4326))";
   ret = sqlite3_prepare_v2(db_handle, sql.c_str(), strlen (sql.c_str()), &stmt, NULL);
   if (ret != SQLITE_OK) {
     LOG_ERROR("SQL error: " + sql);
@@ -214,20 +339,105 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
     uint8_t index = 1;
     sqlite3_reset(stmt);
     sqlite3_clear_bindings;
+    // Tile ID
     sqlite3_bind_int(stmt, index, tileid);
     ++index;
+    // Tile Area
     sqlite3_bind_double(stmt, index, tile_areas[tileid]);
     ++index;
+    // Total Road Length
+    float totalLen = 0;
+    for (auto rclass : rclasses) {
+      totalLen += tile_lengths[tileid][rclass];
+    }
+    sqlite3_bind_double(stmt, index, totalLen);
+    ++index;
+    // Individual Road Class Lengths
     for (auto rclass : rclasses) {
       std::string roadStr = roadClassToString[rclass];
-      sqlite3_bind_double(stmt, index, tile_maps[tileid][rclass]);
+      sqlite3_bind_double(stmt, index, tile_lengths[tileid][rclass]);
       ++index;
+    }
+    // Use tile bounding box corners to make a polygon
+    if (tile_geometries.find(tileid) != tile_geometries.end()) {
+      auto maxx = std::to_string(tile_geometries.at(tileid).maxx());
+      auto minx = std::to_string(tile_geometries.at(tileid).minx());
+      auto maxy = std::to_string(tile_geometries.at(tileid).maxy());
+      auto miny = std::to_string(tile_geometries.at(tileid).miny());
+      std::string polyWKT = "POLYGON (("
+          + minx + " " + miny + ", "
+          + minx + " " + maxy + ", "
+          + maxx + " " + maxy + ", "
+          + maxx + " " + miny + ", "
+          + minx + " " + miny + "))";
+      sqlite3_bind_text (stmt, index, polyWKT.c_str(), polyWKT.length(), SQLITE_STATIC);
+    } else {
+      LOG_ERROR("Geometry for tile " + std::to_string(tileid) + " not found.");
     }
     ret = sqlite3_step (stmt);
     if (ret == SQLITE_DONE || ret == SQLITE_ROW) {
       continue;
     }
     LOG_ERROR("sqlite3_step() error: " + std::string(sqlite3_errmsg(db_handle)));
+  }
+  sqlite3_finalize (stmt);
+  ret = sqlite3_exec (db_handle, "COMMIT", NULL, NULL, &err_msg);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("Error: " + std::string(err_msg));
+    sqlite3_free (err_msg);
+    sqlite3_close (db_handle);
+    return;
+  }
+
+  // Begin adding the statistics for each road type of tile data
+  ret = sqlite3_exec(db_handle, "BEGIN", NULL, NULL, &err_msg);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("Error: " + std::string(err_msg));
+    sqlite3_free(err_msg);
+    sqlite3_close(db_handle);
+    return;
+  }
+
+  sql = "INSERT INTO rclasstiledata (tileid, type, oneway, maxspeed, internaledges, named) ";
+  sql += "VALUES (?, ?, ?, ?, ?, ?)";
+  ret = sqlite3_prepare_v2(db_handle, sql.c_str(), sql.length(), &stmt, NULL);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("SQL error: " + sql);
+    LOG_ERROR(std::string(sqlite3_errmsg(db_handle)));
+    sqlite3_close (db_handle);
+    return;
+  }
+
+  // Fill the roadclass stats for tiles
+  for (auto tileid : tile_ids) {
+    for (auto rclass : rclasses) {
+      uint8_t index = 1;
+      sqlite3_reset(stmt);
+      sqlite3_clear_bindings;
+      // Tile ID (parent tile)
+      sqlite3_bind_int(stmt, index, tileid);
+      ++index;
+      // Roadway type
+      auto type = roadClassToString[rclass];
+      sqlite3_bind_text(stmt, index, type.c_str(), type.length(), SQLITE_STATIC);
+      ++index;
+      // One Way data
+      sqlite3_bind_double(stmt, index, tile_one_way[tileid][rclass]);
+      ++index;
+      // Max speed info
+      sqlite3_bind_double(stmt, index, tile_speed_info[tileid][rclass]);
+      ++index;
+      // Internal edges count
+      sqlite3_bind_int(stmt, index, tile_int_edges[tileid][rclass]);
+      ++index;
+      // Named roads
+      sqlite3_bind_double(stmt, index, tile_named[tileid][rclass]);
+      ret = sqlite3_step (stmt);
+      if (ret == SQLITE_DONE || ret == SQLITE_ROW) {
+        continue;
+      }
+      LOG_ERROR("sqlite3_step() error: " + std::string(sqlite3_errmsg(db_handle)));
+    }
   }
   sqlite3_finalize (stmt);
   ret = sqlite3_exec (db_handle, "COMMIT", NULL, NULL, &err_msg);
@@ -248,7 +458,7 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
   }
   sql = "INSERT INTO countrydata (isocode, motorway, trunk, pmary, secondary, tertiary, unclassified, residential, serviceother) ";
   sql += "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
-  ret = sqlite3_prepare_v2(db_handle, sql.c_str(), strlen (sql.c_str()), &stmt, NULL);
+  ret = sqlite3_prepare_v2(db_handle, sql.c_str(), sql.length(), &stmt, NULL);
   if (ret != SQLITE_OK) {
     LOG_ERROR("SQL error: " + sql);
     LOG_ERROR(std::string(sqlite3_errmsg(db_handle)));
@@ -261,11 +471,13 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
     uint8_t index = 1;
     sqlite3_reset(stmt);
     sqlite3_clear_bindings;
+    // Country ISO
     sqlite3_bind_text(stmt, index, country.c_str(), country.length(), SQLITE_STATIC);
     ++index;
+    // Individual Road Class Lengths
     for (auto rclass : rclasses) {
       std::string roadStr = roadClassToString[rclass];
-      sqlite3_bind_double(stmt, index, country_maps[country][rclass]);
+      sqlite3_bind_double(stmt, index, country_lengths[country][rclass]);
       ++index;
     }
     ret = sqlite3_step (stmt);
@@ -282,7 +494,87 @@ void validator_stats::build_db(const boost::property_tree::ptree& pt) {
     sqlite3_close (db_handle);
     return;
   }
+
+  // Begin adding the statistics for each road type of country data
+  ret = sqlite3_exec(db_handle, "BEGIN", NULL, NULL, &err_msg);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("Error: " + std::string(err_msg));
+    sqlite3_free(err_msg);
+    sqlite3_close(db_handle);
+    return;
+  }
+
+  sql = "INSERT INTO rclassctrydata (isocode, type, oneway, maxspeed, internaledges, named) ";
+  sql += "VALUES (?, ?, ?, ?, ?, ?)";
+  ret = sqlite3_prepare_v2(db_handle, sql.c_str(), sql.length(), &stmt, NULL);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("SQL error: " + sql);
+    LOG_ERROR(std::string(sqlite3_errmsg(db_handle)));
+    sqlite3_close (db_handle);
+    return;
+  }
+
+  // Fill the roadclass stats for countries
+  for (auto country : iso_codes) {
+    for (auto rclass : rclasses) {
+      uint8_t index = 1;
+      sqlite3_reset(stmt);
+      sqlite3_clear_bindings;
+      // ISO (parent ID)
+      sqlite3_bind_text(stmt, index, country.c_str(), country.length(), SQLITE_STATIC);
+      ++index;
+      // Roadway type
+      auto type = roadClassToString[rclass];
+      sqlite3_bind_text(stmt, index, type.c_str(), type.length(), SQLITE_STATIC);
+      ++index;
+      // One Way data
+      sqlite3_bind_double(stmt, index, country_one_way[country][rclass]);
+      ++index;
+      // Max speed info
+      sqlite3_bind_double(stmt, index, country_speed_info[country][rclass]);
+      ++index;
+      // Internal edges count
+      sqlite3_bind_int(stmt, index, country_int_edges[country][rclass]);
+      ++index;
+      // Named Roads
+      sqlite3_bind_double(stmt, index, country_named[country][rclass]);
+      ret = sqlite3_step (stmt);
+      if (ret == SQLITE_DONE || ret == SQLITE_ROW) {
+        continue;
+      }
+      LOG_ERROR("sqlite3_step() error: " + std::string(sqlite3_errmsg(db_handle)));
+    }
+  }
+  sqlite3_finalize (stmt);
+  ret = sqlite3_exec (db_handle, "COMMIT", NULL, NULL, &err_msg);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("Error: " + std::string(err_msg));
+    sqlite3_free (err_msg);
+    sqlite3_close (db_handle);
+    return;
+  }
+
+  // Create Index on geometry column
+  sql = "SELECT CreateSpatialIndex('tiledata', 'geom')";
+  ret = sqlite3_exec (db_handle, sql.c_str(), NULL, NULL, &err_msg);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("Error: " + std::string(err_msg));
+    sqlite3_free (err_msg);
+    sqlite3_close (db_handle);
+    return;
+  }
+  LOG_INFO("Created spatial index");
+
+  sql = "VACUUM ANALYZE";
+  ret = sqlite3_exec (db_handle, sql.c_str(), NULL, NULL, &err_msg);
+  if (ret != SQLITE_OK) {
+    LOG_ERROR("Error: " + std::string(err_msg));
+    sqlite3_free (err_msg);
+    sqlite3_close (db_handle);
+    return;
+  }
   sqlite3_close(db_handle);
+  LOG_INFO("Done writing statistics DB.");
 }
 }
 }

--- a/valhalla/mjolnir/statistics.h
+++ b/valhalla/mjolnir/statistics.h
@@ -14,7 +14,20 @@
 
 using namespace valhalla::baldr;
 using namespace valhalla::midgard;
-
+namespace {
+  const std::map<RoadClass, std::string> roadClassToString =
+    { {RoadClass::kMotorway, "Motorway"}, {RoadClass::kTrunk, "Trunk"}, {RoadClass::kPrimary, "Primary"},
+      {RoadClass::kSecondary, "Secondary"}, {RoadClass::kTertiary, "Tertiary"},
+      {RoadClass::kUnclassified, "Unclassified"},{RoadClass::kResidential, "Residential"},
+      {RoadClass::kServiceOther, "ServiceOther"}
+    };
+  const std::vector<RoadClass> rclasses =
+    { RoadClass::kMotorway, RoadClass::kPrimary,
+      RoadClass::kResidential, RoadClass::kSecondary,
+      RoadClass::kServiceOther, RoadClass::kTertiary,
+      RoadClass::kTrunk, RoadClass::kUnclassified
+    };
+}
 namespace valhalla {
 namespace mjolnir {
 
@@ -55,18 +68,7 @@ class validator_stats {
   std::unordered_map<uint32_t, AABB2> tile_geometries;
   std::vector<std::vector<uint32_t> > dupcounts;
   std::vector<std::vector<float> > densities;
-  std::map<RoadClass, std::string> roadClassToString =
-    { {RoadClass::kMotorway, "Motorway"}, {RoadClass::kTrunk, "Trunk"}, {RoadClass::kPrimary, "Primary"},
-      {RoadClass::kSecondary, "Secondary"}, {RoadClass::kTertiary, "Tertiary"},
-      {RoadClass::kUnclassified, "Unclassified"},{RoadClass::kResidential, "Residential"},
-      {RoadClass::kServiceOther, "ServiceOther"}
-    };
-  std::vector<RoadClass> rclasses =
-    { RoadClass::kMotorway, RoadClass::kPrimary,
-      RoadClass::kResidential, RoadClass::kSecondary,
-      RoadClass::kServiceOther, RoadClass::kTertiary,
-      RoadClass::kTrunk, RoadClass::kUnclassified
-    };
+
 
 public:
 


### PR DESCRIPTION
The statistics are written to /data/valhalla/statistics.sqlite. The data is split between a few tables. There are total road lengths and road class lengths in the main tables for tiles and countries, located in tiledata and countrydata. Tile area is included as well.  

The other metrics now captured are:
* length of named roads
* length of one way roads
* length of roads with speed information
* number of roads/edges that are internal edges

This data is stored in the rclasstiledata and rclassctrydata tables. Each row in those tables has the mentioned data as well as the tile_id or the ISO code, along with the road classification, so for each tile or ISO there are 8 rows of data.