### PR TITLE
Updated fork and exit sign assignment code to prevent erroneous sign assignment when ways are split

### DIFF
--- a/src/mjolnir/node_expander.cc
+++ b/src/mjolnir/node_expander.cc
@@ -31,6 +31,9 @@ node_bundle collect_node_edges(const sequence<Node>::iterator& node_itr,
       if (edge.attributes.link) {
         bundle.link_count++;
       }
+      if (edge.attributes.driveforward) {
+        bundle.driveforward_count++;
+      }
     }
     if(node.is_end()) {
       auto edge_itr = edges[node.end_of];
@@ -48,6 +51,9 @@ node_bundle collect_node_edges(const sequence<Node>::iterator& node_itr,
       }
       if (edge.attributes.link) {
         bundle.link_count++;
+      }
+      if (edge.attributes.driveforward) {
+        bundle.driveforward_count++;
       }
     }
   }

--- a/valhalla/mjolnir/node_expander.h
+++ b/valhalla/mjolnir/node_expander.h
@@ -150,6 +150,7 @@ struct Node {
 struct node_bundle : Node {
   size_t node_count;
   size_t link_count;
+  size_t driveforward_count;
 
   //TODO: to enable two directed edges per loop edge turn this into an
   // unordered_multimap or just a list of pairs
@@ -158,7 +159,8 @@ struct node_bundle : Node {
   node_bundle(const Node& other)
       : Node(other),
         node_count(0),
-        link_count(0) {
+        link_count(0),
+        driveforward_count(0) {
   }
 };
 


### PR DESCRIPTION
BEFORE
23: Take exit 5 on the right onto VA 901 toward Claiborne Parkway/Ashburn Farm Broadlands.
24: Stay straight to take the VA 901 ramp toward Claiborne Parkway/Ashburn Farm Broadlands. 
25: Stay straight to take the VA 901 ramp toward Claiborne Parkway/Ashburn Farm Broadlands.
26: Turn right onto Claiborne Parkway/VA 901. 

AFTER
23: Take exit 5 on the right onto VA 901 toward Claiborne Parkway/Ashburn Farm Broadlands.
24: Turn right onto Claiborne Parkway/VA 901.

![screenshot from 2015-07-07 15 02 54](https://cloud.githubusercontent.com/assets/7515853/8554724/51f9ed7a-24b9-11e5-8a50-80b9c9755c12.png)
