### PR TITLE
Update GraphEnhancer and use template classes

### DIFF
--- a/src/mjolnir/adminbenchmark.cc
+++ b/src/mjolnir/adminbenchmark.cc
@@ -51,7 +51,7 @@ boost::filesystem::path config_file_path;
 
 std::unordered_map<uint32_t,multi_polygon_type> GetAdminInfo(
             sqlite3* db_handle, std::unordered_map<uint32_t,
-            bool>& drive_on_right, const AABB2& aabb) {
+            bool>& drive_on_right, const AABB2<PointLL>& aabb) {
   // Polys (return)
   std::unordered_map<uint32_t, multi_polygon_type> polys;
 

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -301,7 +301,7 @@ uint32_t CreateSimpleTurnRestriction(const uint64_t wayid, const size_t endnode,
 
 // Walk the shape and look for any empty tiles that the shape intersects
 void CheckForIntersectingTiles(const GraphId& tile1, const GraphId& tile2,
-                const Tiles& tiling, std::vector<PointLL>& shape,
+                const Tiles<PointLL>& tiling, std::vector<PointLL>& shape,
                 DataQuality& stats) {
   // Walk the shape segments until we are outside
   uint32_t current_tile = tile1.tileid();
@@ -361,7 +361,7 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
   sequence<Node> nodes(nodes_file, false);
 
   const auto& tl = hierarchy.levels().rbegin();
-  Tiles tiling = tl->second.tiles;
+  Tiles<PointLL> tiling = tl->second.tiles;
 
   // Method to get the shape for an edge - since LL is stored as a pair of
   // floats we need to change into PointLL to get length of an edge

--- a/src/mjolnir/statistics.cc
+++ b/src/mjolnir/statistics.cc
@@ -82,7 +82,7 @@ void validator_stats::add_tile_area (const uint32_t& tile_id, const float area) 
   tile_areas[tile_id] = area;
 }
 
-void validator_stats::add_tile_geom (const uint32_t& tile_id, const AABB2 geom) {
+void validator_stats::add_tile_geom (const uint32_t& tile_id, const AABB2<PointLL> geom) {
   tile_geometries[tile_id] = geom;
 }
 
@@ -120,7 +120,7 @@ const std::unordered_map<std::string, std::unordered_map<RoadClass, float, valid
 
 const std::unordered_map<uint32_t, float>& validator_stats::get_tile_areas() const { return tile_areas; }
 
-const std::unordered_map<uint32_t, AABB2>& validator_stats::get_tile_geometries() const { return tile_geometries; }
+const std::unordered_map<uint32_t, AABB2<PointLL>>& validator_stats::get_tile_geometries() const { return tile_geometries; }
 
 const std::vector<uint32_t> validator_stats::get_dups(int level) const { return dupcounts[level]; }
 

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -145,7 +145,7 @@ struct builder_stats {
 };
 
 // Get stops within a tile's bounding box
-std::vector<Stop> GetStops(sqlite3 *db_handle, const AABB2& aabb) {
+std::vector<Stop> GetStops(sqlite3 *db_handle, const AABB2<PointLL>& aabb) {
   // Form query -- for now ignore egress points
 
   std::string sql = "SELECT stop_key, stop_id, onestop_id, osm_way_id,";

--- a/valhalla/mjolnir/statistics.h
+++ b/valhalla/mjolnir/statistics.h
@@ -65,7 +65,7 @@ class validator_stats {
   std::unordered_set<uint32_t> tile_ids;
   std::unordered_set<std::string> iso_codes;
   std::unordered_map<uint32_t, float> tile_areas;
-  std::unordered_map<uint32_t, AABB2> tile_geometries;
+  std::unordered_map<uint32_t, AABB2<PointLL>> tile_geometries;
   std::vector<std::vector<uint32_t> > dupcounts;
   std::vector<std::vector<float> > densities;
 
@@ -96,7 +96,7 @@ public:
 
   void add_tile_area (const uint32_t& tile_id, const float area);
 
-  void add_tile_geom (const uint32_t& tile_id, const AABB2 geom);
+  void add_tile_geom (const uint32_t& tile_id, const AABB2<PointLL> geom);
 
   void add_density (float density, int level);
 
@@ -128,7 +128,7 @@ public:
 
   const std::unordered_map<uint32_t, float>& get_tile_areas() const;
 
-  const std::unordered_map<uint32_t, AABB2>& get_tile_geometries() const;
+  const std::unordered_map<uint32_t, AABB2<PointLL>>& get_tile_geometries() const;
 
   const std::vector<uint32_t> get_dups(int level) const;
 


### PR DESCRIPTION
Separate GraphEnhancer into 2 passes:
1) Set link use to ramp or turn channel and set opposing local edge index,
2) Set edge transitions.
Needed to separate this since edge transitions depend on turn channel.
Also, update stop impact logic for turn channels.