### PR TITLE
breakfix: shortcut edges being too distinct

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -359,9 +359,6 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
     std::map<GraphId, size_t>::const_iterator tile_end,
     std::promise<DataQuality>& result) {
 
-  std::string thread_id = static_cast<const std::ostringstream&>(std::ostringstream() << std::this_thread::get_id()).str();
-  LOG_INFO("Thread " + thread_id + " started");
-
   sequence<OSMWay> ways(ways_file, false);
   sequence<OSMWayNode> way_nodes(way_nodes_file, false);
   sequence<Edge> edges(edges_file, false);
@@ -688,12 +685,12 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
       graphtile.StoreTileData(hierarchy, tile_start->first);
 
       // Made a tile
-      LOG_DEBUG((boost::format("Thread %1% wrote tile %2%: %3% bytes") % thread_id % tile_start->first % graphtile.size()).str());
+      LOG_DEBUG((boost::format("Wrote tile %1%: %2% bytes") % tile_start->first % graphtile.size()).str());
     }// Whatever happens in Vegas..
     catch(std::exception& e) {
       // ..gets sent back to the main thread
       result.set_exception(std::current_exception());
-      LOG_ERROR((boost::format("Thread %1% failed tile %2%: %3%") % thread_id % tile_start->first % e.what()).str());
+      LOG_ERROR((boost::format("Failed tile %1%: %2%") % tile_start->first % e.what()).str());
       return;
     }
   }


### PR DESCRIPTION
in my previous pr i ended up refactoring the shortcut building code to recompute the length of a given edge, this would lead to a more accurate (increasing in the number of contracted edges) estimation of a given edge's length but had the unfortunate side effect..

basically when it would compute the length of an edge the next time it would use the shape but in possibly a different direction. compounding trig functions and the use of only floating point precision means that if the value ended up being near x.5f the rounding could go one way or another depending which directed_edge of a given edge you were computing. anyway having the length be off by one meant that looking up the edge_info failed and so the two edges would not be considered directed_edges of the same edge.

what made this doubly tricky to find was that it required you to have admin info to expose it. must have had to do with the decision about whether or not two edges could contract based on matching admin info.

so i've reverted this to just add up the rounded lengths as before.