### PR TITLE
consider full length and just end points of fairly short segments of road

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -546,7 +546,7 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
               std::vector<PointLL> resampled;
               //if it is really short or a bridge just do both ends
               auto interval = POSTING_INTERVAL;
-              if(length <= POSTING_INTERVAL || w.bridge()) {
+              if(length < POSTING_INTERVAL * 3 || w.bridge()) {
                 resampled = {shape.front(), shape.back()};
                 interval = length;
               }

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -319,7 +319,7 @@ uint32_t GetGrade(const std::unique_ptr<const valhalla::skadi::sample>& sample, 
   std::vector<PointLL> resampled;
   //if it was really short just do both ends
   auto interval = POSTING_INTERVAL;
-  if(length <= POSTING_INTERVAL) {
+  if(length < POSTING_INTERVAL * 3) {
     resampled = {shape.front(), shape.back()};
     interval = length;
   }


### PR DESCRIPTION
if an edge is less than 180m it will just use the end points to compute the weighted grade. this is important because the resampling doesnt sample the end point which for short edges means you can miss a significant portion of the edge.