### PR TITLE
use lists to avoid reallocation

### DIFF
--- a/src/mjolnir/edgeinfobuilder.cc
+++ b/src/mjolnir/edgeinfobuilder.cc
@@ -27,9 +27,13 @@ void EdgeInfoBuilder::AddNameOffset(const uint32_t offset) {
 }
 
 // Set the shape of the edge. Encode the vector of lat,lng to a string.
-void EdgeInfoBuilder::set_shape(const std::list<PointLL>& shape) {
-  encoded_shape_ = midgard::encode<std::list<PointLL> >(shape);
+template <class shape_container_t>
+void EdgeInfoBuilder::set_shape(const shape_container_t& shape) {
+  encoded_shape_ = midgard::encode<shape_container_t>(shape);
 }
+template void EdgeInfoBuilder::set_shape<std::vector<PointLL> >(const std::vector<PointLL>&);
+template void EdgeInfoBuilder::set_shape<std::list<PointLL> >(const std::list<PointLL>&);
+
 
 // Set the encoded shape string.
 void EdgeInfoBuilder::set_encoded_shape(const std::string& encoded_shape) {

--- a/src/mjolnir/edgeinfobuilder.cc
+++ b/src/mjolnir/edgeinfobuilder.cc
@@ -27,8 +27,8 @@ void EdgeInfoBuilder::AddNameOffset(const uint32_t offset) {
 }
 
 // Set the shape of the edge. Encode the vector of lat,lng to a string.
-void EdgeInfoBuilder::set_shape(const std::vector<PointLL>& shape) {
-  encoded_shape_ = midgard::encode<std::vector<PointLL> >(shape);
+void EdgeInfoBuilder::set_shape(const std::list<PointLL>& shape) {
+  encoded_shape_ = midgard::encode<std::list<PointLL> >(shape);
 }
 
 // Set the encoded shape string.

--- a/src/mjolnir/ferry_connections.cc
+++ b/src/mjolnir/ferry_connections.cc
@@ -3,7 +3,7 @@
 #include <queue>
 #include <unordered_map>
 
-#include <valhalla/midgard/pointll.h>
+#include <valhalla/midgard/util.h>
 
 namespace valhalla {
 namespace mjolnir {
@@ -47,8 +47,7 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
   // Method to get the shape for an edge - since LL is stored as a pair of
   // floats we need to change into PointLL to get length of an edge
   const auto EdgeShape = [&way_nodes](size_t idx, const size_t count) {
-    std::vector<PointLL> shape;
-    shape.reserve(count);
+    std::list<PointLL> shape;
     for (size_t i = 0; i < count; ++i) {
       auto node = (*way_nodes[idx++]).node;
       shape.emplace_back(node.lng, node.lat);
@@ -142,7 +141,7 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
 
       // Get cost - need the length and speed of the edge
       auto shape = EdgeShape(edge.llindex_, edge.attributes.llcount);
-      float cost = current_cost + (PointLL::Length(shape) * 3.6f) / w.speed();
+      float cost = current_cost + (valhalla::midgard::length(shape) * 3.6f) / w.speed();
 
       // Check if already in adj set - skip if cost is higher than prior path
       if (node_status[endnode].set == kTemporary) {
@@ -207,8 +206,7 @@ bool ShortFerry(const uint32_t node_index, node_bundle& bundle,
   // Method to get the shape for an edge - since LL is stored as a pair of
   // floats we need to change into PointLL to get length of an edge
   const auto EdgeShape = [&way_nodes](size_t idx, const size_t count) {
-    std::vector<PointLL> shape;
-    shape.reserve(count);
+    std::list<PointLL> shape;
     for (size_t i = 0; i < count; ++i) {
       auto node = (*way_nodes[idx++]).node;
       shape.emplace_back(node.lng, node.lat);
@@ -227,7 +225,7 @@ bool ShortFerry(const uint32_t node_index, node_bundle& bundle,
       auto bundle2 = collect_node_edges(end_node_itr, nodes, edges);
       if (bundle2.node.attributes_.non_ferry_edge) {
         auto shape = EdgeShape(edge.first.llindex_, edge.first.attributes.llcount);
-        if (PointLL::Length(shape) < 2000.0f) {
+        if (midgard::length(shape) < 2000.0f) {
           const OSMWay w = *ways[edge.first.wayindex_];
           wayid = w.way_id();
           short_edge = true;

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -311,9 +311,9 @@ void CheckForIntersectingTiles(const GraphId& tile1, const GraphId& tile2,
                 DataQuality& stats) {
   // Walk the shape segments until we are outside
   uint32_t current_tile = tile1.tileid();
-  auto shape1 = shape.begin();
+  auto shape1 = shape.cbegin();
   auto shape2 = std::next(shape1);
-  while (shape2 < shape.end()) {
+  while (shape2 != shape.cend()) {
     uint32_t next_tile = tiling.TileId(shape2->lat(), shape2->lng());
     if (next_tile != current_tile) {
       // If a neighbor we can just add this tile
@@ -347,7 +347,7 @@ void CheckForIntersectingTiles(const GraphId& tile1, const GraphId& tile2,
 
     // Increment
     shape1 = shape2;
-    shape2++;
+    std::next(shape2);
   }
 }
 

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -347,7 +347,7 @@ void CheckForIntersectingTiles(const GraphId& tile1, const GraphId& tile2,
 
     // Increment
     shape1 = shape2;
-    std::next(shape2);
+    shape2 = std::next(shape2);
   }
 }
 

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -307,12 +307,12 @@ uint32_t CreateSimpleTurnRestriction(const uint64_t wayid, const size_t endnode,
 
 // Walk the shape and look for any empty tiles that the shape intersects
 void CheckForIntersectingTiles(const GraphId& tile1, const GraphId& tile2,
-                const Tiles<PointLL>& tiling, std::vector<PointLL>& shape,
+                const Tiles<PointLL>& tiling, std::list<PointLL>& shape,
                 DataQuality& stats) {
   // Walk the shape segments until we are outside
   uint32_t current_tile = tile1.tileid();
   auto shape1 = shape.begin();
-  auto shape2 = shape1 + 1;
+  auto shape2 = std::next(shape1);
   while (shape2 < shape.end()) {
     uint32_t next_tile = tiling.TileId(shape2->lat(), shape2->lng());
     if (next_tile != current_tile) {
@@ -370,8 +370,7 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
   // Method to get the shape for an edge - since LL is stored as a pair of
   // floats we need to change into PointLL to get length of an edge
   const auto EdgeShape = [&way_nodes](size_t idx, const size_t count) {
-    std::vector<PointLL> shape;
-    shape.reserve(count);
+    std::list<PointLL> shape;
     for (size_t i = 0; i < count; ++i) {
       auto node = (*way_nodes[idx++]).node;
       shape.emplace_back(node.lng, node.lat);
@@ -537,13 +536,13 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
               added);
 
             //length
-            auto length = PointLL::Length(shape);
+            auto length = valhalla::midgard::length(shape);
 
             //grade estimation
             uint32_t forward_grade = 6, reverse_grade = 6;
             if(sample && !w.tunnel()) {
               //evenly sample the shape
-              std::vector<PointLL> resampled;
+              std::list<PointLL> resampled;
               //if it is really short or a bridge just do both ends
               auto interval = POSTING_INTERVAL;
               if(length < POSTING_INTERVAL * 3 || w.bridge()) {

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -501,7 +501,7 @@ uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
                                        const GraphId& nodea,
                                        const baldr::GraphId& nodeb,
                                        const uint64_t wayid,
-                                       const std::vector<PointLL>& lls,
+                                       const std::list<PointLL>& lls,
                                        const std::vector<std::string>& names,
                                        bool& added) {
   // If we haven't yet added edge info for this edge tuple

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -497,11 +497,12 @@ bool GraphTileBuilder::HasEdgeInfo(const uint32_t edgeindex, const baldr::GraphI
 }
 
 // Add edge info
+template <class shape_container_t>
 uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
                                        const GraphId& nodea,
                                        const baldr::GraphId& nodeb,
                                        const uint64_t wayid,
-                                       const std::list<PointLL>& lls,
+                                       const shape_container_t& lls,
                                        const std::vector<std::string>& names,
                                        bool& added) {
   // If we haven't yet added edge info for this edge tuple
@@ -544,6 +545,12 @@ uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
     return existing_edge_offset_item->second;
   }
 }
+template uint32_t GraphTileBuilder::AddEdgeInfo<std::vector<PointLL> >
+  (const uint32_t edgeindex, const GraphId&, const baldr::GraphId&,const uint64_t,
+   const std::vector<PointLL>&, const std::vector<std::string>&, bool&);
+template uint32_t GraphTileBuilder::AddEdgeInfo<std::list<PointLL> >
+  (const uint32_t edgeindex, const GraphId&, const baldr::GraphId&,const uint64_t,
+   const std::list<PointLL>&, const std::vector<std::string>&, bool&);
 
 // Add a name to the text list
 uint32_t GraphTileBuilder::AddName(const std::string& name) {

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -316,7 +316,7 @@ bool IsEnteringEdgeOfContractedNode(const GraphId& node, const GraphId& edge,
 
 uint32_t GetGrade(const std::unique_ptr<const valhalla::skadi::sample>& sample, const std::vector<PointLL>& shape, const float length, const bool forward) {
   //evenly sample the shape
-  std::vector<PointLL> resampled;
+  std::list<PointLL> resampled;
   //if it was really short just do both ends
   auto interval = POSTING_INTERVAL;
   if(length < POSTING_INTERVAL * 3) {
@@ -384,16 +384,10 @@ void AddShortcutEdges(
       // Get the shape for this edge. If this initial directed edge is not
       // forward - reverse the shape so the edge info stored is forward for
       // the first added edge info
-      std::unique_ptr<const EdgeInfo> edgeinfo = tile->edgeinfo(
-          directededge->edgeinfo_offset());
-      std::vector<PointLL> shape;
-      if (directededge->forward()) {
-        shape = edgeinfo->shape();
-      } else {
-        // Reverse the shape
-        std::vector<PointLL> edgeshape = edgeinfo->shape();
-        shape.insert(shape.end(), edgeshape.rbegin(), edgeshape.rend());
-      }
+      std::unique_ptr<const EdgeInfo> edgeinfo = tile->edgeinfo(directededge->edgeinfo_offset());
+      std::vector<PointLL> shape = edgeinfo->shape();
+      if (!directededge->forward())
+        std::reverse(shape.begin(), shape.end());
 
       // Get names - they apply over all edges of the shortcut
       std::vector<std::string> names = tile->GetNames(

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -38,11 +38,11 @@ void TestDuplicateEdgeInfo() {
   test_graph_tile_builder test;
   //add edge info for node 0 to node 1
   bool added = false;
-  test.AddEdgeInfo(0, GraphId(0,2,0), GraphId(0,2,1), 1234, {{0, 0}, {1, 1}}, {"einzelweg"}, added);
+  test.AddEdgeInfo(0, GraphId(0,2,0), GraphId(0,2,1), 1234, std::list<PointLL>{{0, 0}, {1, 1}}, {"einzelweg"}, added);
   if(test.edge_offset_map_.size() != 1)
     throw std::runtime_error("There should be exactly one of these in here");
   //add edge info for node 1 to node 0
-  test.AddEdgeInfo(0, GraphId(0,2,1), GraphId(0,2,0), 1234, {{1, 1}, {0, 0}}, {"einzelweg"}, added);
+  test.AddEdgeInfo(0, GraphId(0,2,1), GraphId(0,2,0), 1234, std::list<PointLL>{{1, 1}, {0, 0}}, {"einzelweg"}, added);
   if(test.edge_offset_map_.size() != 1)
     throw std::runtime_error("There should still be exactly one of these in here");
 }

--- a/valhalla/mjolnir/edgeinfobuilder.h
+++ b/valhalla/mjolnir/edgeinfobuilder.h
@@ -45,7 +45,8 @@ class EdgeInfoBuilder {
    * @param  shape  List of lat,lng points describing the
    *                shape of the edge.
    */
-  void set_shape(const std::list<PointLL>& shape);
+  template <class shape_container_t>
+  void set_shape(const shape_container_t& shape);
 
   /**
    * Set the encoded shape string.

--- a/valhalla/mjolnir/edgeinfobuilder.h
+++ b/valhalla/mjolnir/edgeinfobuilder.h
@@ -2,6 +2,7 @@
 #define VALHALLA_MJOLNIR_EDGEINFOBUILDER_H_
 
 #include <vector>
+#include <list>
 #include <string>
 #include <iostream>
 
@@ -44,7 +45,7 @@ class EdgeInfoBuilder {
    * @param  shape  List of lat,lng points describing the
    *                shape of the edge.
    */
-  void set_shape(const std::vector<PointLL>& shape);
+  void set_shape(const std::list<PointLL>& shape);
 
   /**
    * Set the encoded shape string.

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -214,10 +214,11 @@ class GraphTileBuilder : public baldr::GraphTile {
    *
    * @return  The edge info offset that will be stored in the directed edge.
    */
+  template <class shape_container_t>
   uint32_t AddEdgeInfo(const uint32_t edgeindex, const baldr::GraphId& nodea,
                        const baldr::GraphId& nodeb,
                        const uint64_t wayid,
-                       const std::list<PointLL>& lls,
+                       const shape_container_t& lls,
                        const std::vector<std::string>& names,
                        bool& added);
 

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -217,7 +217,7 @@ class GraphTileBuilder : public baldr::GraphTile {
   uint32_t AddEdgeInfo(const uint32_t edgeindex, const baldr::GraphId& nodea,
                        const baldr::GraphId& nodeb,
                        const uint64_t wayid,
-                       const std::vector<PointLL>& lls,
+                       const std::list<PointLL>& lls,
                        const std::vector<std::string>& names,
                        bool& added);
 


### PR DESCRIPTION
there are places where we work with shape that we dont know its size apriori. there are also places were we add arbitrary bits of shape together. both of these things suck when using vectors because of reallocations. it turned out that none of this stuff required access by index either so no loss there.

this pr changes that stuff to use lists so that we can avoid reallocations. this made no difference in a small import like PA. we'll see if it makes a difference for larger imports.

the main reason i did this was because elevation sampling has no clue how many points it will end up generating so its hard to accurately preallocate space. this also benefits hierarchy building as it will `splice` arbitrary sections of road together. this operation is O(1) for lists and O(n) for vectors, plus vectors would be reallocating

ive also templated the methods to work with either lists or vectors depending on whats needed so as not to break stuff that does actually need `random_access_iterators`