### PR TITLE
Updated logic to not create shortcut edges on roundabouts

### DIFF
--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -98,6 +98,11 @@ bool EdgesMatch(const GraphTile* tile, const DirectedEdge* edge1,
     return false;
   }
 
+  // Neither directed edge can be a roundabout.
+  if (edge1->roundabout() || edge2->roundabout()) {
+    return false;
+  }
+
   // classification, link, use, and attributes must also match.
   // NOTE: might want "better" bridge attribution. Seems most overpasses
   // get marked as a bridge and lead to less shortcuts - so we don't consider


### PR DESCRIPTION
thanks @dnesbitt61 

Long routes passing through roundabouts could have the incorrect exit count
BEFORE
Enter the roundabout and take the 2nd exit.
AFTER
Enter the roundabout and take the 3rd exit.

![screenshot from 2015-10-27 09 52 41](https://cloud.githubusercontent.com/assets/7515853/10760161/8a9d39ae-7c91-11e5-9449-5359b889bebb.png)

@costales This will help many routes in Spain
