### PR TITLE
matches with the rest of the programs logging

### DIFF
--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -876,14 +876,13 @@ void HierarchyBuilder::Build(const boost::property_tree::ptree& pt) {
 
     // Form all tiles in new level
     FormTilesInNewLevel(base_level->second, new_level->second, info, sample);
-    LOG_INFO((boost::format("Created %1% shortcuts") % info.shortcutcount_).str());
 
     // Form connections (directed edges) in the base level tiles to
     // the new level. Note that the new tiles are created before adding
     // connections to base tiles. That way all access to old tiles is
     // complete and the base tiles can be updated.
     ConnectBaseLevelToNewLevel(base_level->second, new_level->second, info);
-    LOG_INFO("Finished");
+    LOG_INFO("Finished with " + std::to_string(info.shortcutcount_) + " shortcuts");
   }
 }
 


### PR DESCRIPTION
the other builders log more so in this manner. for the sake of symmetry and less log lines this seemed better