### PR TITLE
dump a transit schedule.

### DIFF
--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -824,11 +824,6 @@ uint32_t GetStopImpact(uint32_t from, uint32_t to,
     return 0;
   }
 
-  // Shared, Dedicated, and Separated Lanes going to Cycleways.
-  if (edges[from].cyclelane() != CycleLane::kNone && edges[to].use() == Use::kCycleway) {
-    return 0;
-  }
-
   // No stop impact going from a turn channel. Stop impact will
   // be set entering a turn channel
   if (edges[from].use() == Use::kTurnChannel) {

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -824,6 +824,11 @@ uint32_t GetStopImpact(uint32_t from, uint32_t to,
     return 0;
   }
 
+  // Shared, Dedicated, and Separated Lanes going to Cycleways.
+  if (edges[from].cyclelane() != CycleLane::kNone && edges[to].use() == Use::kCycleway) {
+    return 0;
+  }
+
   // No stop impact going from a turn channel. Stop impact will
   // be set entering a turn channel
   if (edges[from].use() == Use::kTurnChannel) {

--- a/src/mjolnir/transit_stop_query.cc
+++ b/src/mjolnir/transit_stop_query.cc
@@ -30,6 +30,26 @@ using namespace valhalla::mjolnir;
 
 namespace bpo = boost::program_options;
 
+// Get PBF transit data given a GraphId / tile
+Transit read_pbf(const GraphId& id, const TileHierarchy& hierarchy,
+                 const std::string& transit_dir) {
+  std::string fname = GraphTile::FileSuffix(id, hierarchy);
+  fname = fname.substr(0, fname.size() - 3) + "pbf";
+  std::string file_name = transit_dir + '/' + fname;
+  std::fstream file(file_name, std::ios::in | std::ios::binary);
+  if(!file) {
+    throw std::runtime_error("Couldn't load " + file_name);
+  }
+  std::string buffer((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  google::protobuf::io::ArrayInputStream as(static_cast<const void*>(buffer.c_str()), buffer.size());
+  google::protobuf::io::CodedInputStream cs(static_cast<google::protobuf::io::ZeroCopyInputStream*>(&as));
+  cs.SetTotalBytesLimit(buffer.size() * 2, buffer.size() * 2);
+  Transit transit;
+  if(!transit.ParseFromCodedStream(&cs))
+    throw std::runtime_error("Couldn't load " + file_name);
+  return transit;
+}
+
 // Log all scheduled departures from a stop
 void LogDepartures(const Transit& transit, const GraphId& stopid) {
   // Check if there are no schedule stop pairs in this tile
@@ -74,6 +94,149 @@ void LogDepartures(const Transit& transit, const GraphId& stopid) {
   }
 }
 
+void GetNextDeparture(const TileHierarchy hierarchy,
+                      const std::string transit_dir,
+                      GraphId& orig_graphid, const GraphId& destid,
+                      const uint32_t tripid,std::string& origin_time) {
+
+  if (orig_graphid.Is_Valid()) {
+
+    Transit transit = read_pbf(orig_graphid, hierarchy, transit_dir);
+
+    for (uint32_t i = 0; i < transit.stop_pairs_size(); i++) {
+
+      const Transit_StopPair& sp = transit.stop_pairs(i);
+      if (sp.trip_key() == tripid && orig_graphid == GraphId(sp.origin_graphid())) {
+
+         int total_seconds = sp.origin_departure_time();
+         int seconds = total_seconds % 60;
+         int minutes = (total_seconds / 60) % 60;
+         int hours = total_seconds / 3600;
+
+         std::stringstream ss;
+         ss << std::setfill('0') << std::setw(2) << hours;
+         ss << ":";
+         ss << std::setfill('0') << std::setw(2) << minutes;
+         ss << ":";
+         ss << std::setfill('0') << std::setw(2) << seconds;
+
+         if (origin_time == ss.str()) {
+
+           total_seconds = sp.destination_arrival_time();
+           seconds = total_seconds % 60;
+           minutes = (total_seconds / 60) % 60;
+           hours = total_seconds / 3600;
+
+           ss.str("");
+           ss << std::setfill('0') << std::setw(2) << hours;
+           ss << ":";
+           ss << std::setfill('0') << std::setw(2) << minutes;
+           ss << ":";
+           ss << std::setfill('0') << std::setw(2) << seconds;
+
+           LOG_INFO("Trip:\t" + sp.trip_headsign() +
+                    "\tDep Time:\t" + origin_time +
+                    "\tArr Time:\t" + ss.str() +
+                    "\tOrigin ----> Dest\t" + sp.origin_onestop_id() +
+                    " ----> " + sp.destination_onestop_id());
+
+           origin_time = ss.str();
+           orig_graphid = GraphId(sp.destination_graphid());
+
+           if (destid == orig_graphid) {//we are done.
+             orig_graphid = GraphId();
+             origin_time = "";
+           }
+
+           if (orig_graphid.Is_Valid())
+             return;
+         }
+      }
+    }
+  }
+  orig_graphid = GraphId();
+  origin_time = "";
+}
+
+void LogSchedule(const TileHierarchy hierarchy, const std::string transit_dir,
+                 const GraphId& originid, const GraphId& destid,
+                 const uint32_t tripid, const std::string time) {
+
+  Transit transit = read_pbf(originid, hierarchy, transit_dir);
+
+  // Check if there are no schedule stop pairs in this tile
+  if (transit.stop_pairs_size() == 0) {
+    LOG_ERROR("No stop pairs in the PBF tile");
+    return;
+  }
+  // Iterate through the stop pairs in this tile and form Valhalla departure
+  // records
+  uint32_t tileid;
+  GraphId orig_graphid;
+  std::string origin_time;
+  LOG_INFO("Schedule:");
+  for (uint32_t i = 0; i < transit.stop_pairs_size(); i++) {
+    const Transit_StopPair& sp = transit.stop_pairs(i);
+
+    // Skip stop pair if either stop graph Id is invalid
+    orig_graphid = GraphId(sp.origin_graphid());
+    if (!orig_graphid.Is_Valid() ||
+        !GraphId(sp.destination_graphid()).Is_Valid()) {
+      continue;
+    }
+
+    //do we have the correct stop?
+    if (orig_graphid == originid) {
+
+      //do we have the correct trip?
+      if (sp.trip_key() == tripid) {
+
+        int total_seconds = sp.origin_departure_time();
+        int seconds = total_seconds % 60;
+        int minutes = (total_seconds / 60) % 60;
+        int hours = total_seconds / 3600;
+
+        std::stringstream ss;
+        ss << std::setfill('0') << std::setw(2) << hours;
+        ss << ":";
+        ss << std::setfill('0') << std::setw(2) << minutes;
+        ss << ":";
+        ss << std::setfill('0') << std::setw(2) << seconds;
+
+        //do we have the correct time?
+        if (time == ss.str()) {
+          // now lets save the destination time and id...this is our new origin
+          total_seconds = sp.destination_arrival_time();
+          seconds = total_seconds % 60;
+          minutes = (total_seconds / 60) % 60;
+          hours = total_seconds / 3600;
+
+          ss.str("");
+          ss << std::setfill('0') << std::setw(2) << hours;
+          ss << ":";
+          ss << std::setfill('0') << std::setw(2) << minutes;
+          ss << ":";
+          ss << std::setfill('0') << std::setw(2) << seconds;
+          origin_time = ss.str();
+          orig_graphid = GraphId(sp.destination_graphid());
+
+          LOG_INFO("Trip:\t" + sp.trip_headsign() +
+                   "\tDep Time:\t" + time +
+                   "\tArr Time:\t" + origin_time +
+                   "\tOrigin ----> Dest\t" + sp.origin_onestop_id() +
+                   " ----> " + sp.destination_onestop_id());
+
+          break;
+        }
+      }
+    }
+  }
+
+  while (orig_graphid.Is_Valid() && !origin_time.empty())
+    GetNextDeparture(hierarchy, transit_dir, orig_graphid, destid, tripid, origin_time);
+
+}
+
 // Log the list of routes within the tile
 void LogRoutes(const Transit& transit) {
   LOG_INFO("Routes:");
@@ -95,26 +258,6 @@ GraphId GetGraphId(Transit& transit, const std::string& onestop_id) {
   return GraphId();
 }
 
-// Get PBF transit data given a GraphId / tile
-Transit read_pbf(const GraphId& id, const TileHierarchy& hierarchy,
-                 const std::string& transit_dir) {
-  std::string fname = GraphTile::FileSuffix(id, hierarchy);
-  fname = fname.substr(0, fname.size() - 3) + "pbf";
-  std::string file_name = transit_dir + '/' + fname;
-  std::fstream file(file_name, std::ios::in | std::ios::binary);
-  if(!file) {
-    throw std::runtime_error("Couldn't load " + file_name);
-  }
-  std::string buffer((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-  google::protobuf::io::ArrayInputStream as(static_cast<const void*>(buffer.c_str()), buffer.size());
-  google::protobuf::io::CodedInputStream cs(static_cast<google::protobuf::io::ZeroCopyInputStream*>(&as));
-  cs.SetTotalBytesLimit(buffer.size() * 2, buffer.size() * 2);
-  Transit transit;
-  if(!transit.ParseFromCodedStream(&cs))
-    throw std::runtime_error("Couldn't load " + file_name);
-  return transit;
-}
-
 // Main method for testing a single path
 int main(int argc, char *argv[]) {
   bpo::options_description options("transit_stop_query\n"
@@ -122,14 +265,18 @@ int main(int argc, char *argv[]) {
   "transit_stop_query is a simple command line test tool to log transit stop info."
   "\n");
 
-  std::string config, onestop;
+  std::string config, origin, dest, time;
   float lat,lng;
+  int tripid = 0;
   options.add_options()
       ("help,h", "Print this help message.")
       ("version,v", "Print the version of this software.")
       ("lat,y", boost::program_options::value<float>(&lat))
       ("lng,x", boost::program_options::value<float>(&lng))
-      ("onestop,o", boost::program_options::value<std::string>(&onestop))
+      ("origin,o", boost::program_options::value<std::string>(&origin))
+      ("dest,d", boost::program_options::value<std::string>(&dest))
+      ("tripid,i", boost::program_options::value<int>(&tripid))
+      ("time,t", boost::program_options::value<std::string>(&time))
       ("conf,c", bpo::value<std::string>(&config), "Valhalla configuration file");
 
   bpo::variables_map vm;
@@ -146,7 +293,7 @@ int main(int argc, char *argv[]) {
     return true;
   }
 
-  for (auto arg : std::vector<std::string> { "onestop", "lat", "lng", "conf" }) {
+  for (auto arg : std::vector<std::string> { "origin", "lat", "lng", "conf" }) {
     if (vm.count(arg) == 0) {
       std::cerr << "The <" << arg
           << "> argument was not provided, but is mandatory\n\n";
@@ -181,11 +328,22 @@ int main(int argc, char *argv[]) {
   Transit transit = read_pbf(tile, hierarchy, *transit_dir);
 
   // Get the graph Id of the stop
-  GraphId stopid = GetGraphId(transit, onestop);
+  GraphId originid = GetGraphId(transit, origin);
 
-  // Log departures from this stop
-  LogDepartures(transit, stopid);
+  if (tripid == 0 || time.empty()) {
+    // Log departures from this stop
+    LogDepartures(transit, originid);
 
-  // Log routes in this tile
-  LogRoutes(transit);
+    // Log routes in this tile
+    LogRoutes(transit);
+  }
+  else {
+    GraphId destid = GraphId();
+    if (!dest.empty()) {
+      // Get the graph Id of the stop
+      destid = GetGraphId(transit, dest);
+    }
+    LogSchedule(hierarchy, *transit_dir, originid, destid, tripid, time);
+  }
+
 }

--- a/src/mjolnir/transit_stop_query.cc
+++ b/src/mjolnir/transit_stop_query.cc
@@ -68,6 +68,7 @@ void LogDepartures(const Transit& transit, const GraphId& stopid) {
 
       LOG_INFO("LineID: " + std::to_string(sp.line_id()) +
                " Route: " + std::to_string(sp.route_index()) +
+               " Trip: " + std::to_string(sp.trip_key()) +
                " Dep Time: " + ss.str());
     }
   }

--- a/src/mjolnir/transit_stop_query.cc
+++ b/src/mjolnir/transit_stop_query.cc
@@ -3,6 +3,7 @@
 #include "proto/transit.pb.h"
 
 #include <unordered_map>
+#include <map>
 #include <fstream>
 #include <iostream>
 #include <boost/filesystem/operations.hpp>
@@ -52,9 +53,22 @@ void LogDepartures(const Transit& transit, const GraphId& stopid) {
     }
 
     if (orig_graphid == stopid) {
+
+      int total_seconds = sp.origin_departure_time();
+      int seconds = total_seconds % 60;
+      int minutes = (total_seconds / 60) % 60;
+      int hours = total_seconds / 3600;
+
+      std::stringstream ss;
+      ss << std::setfill('0') << std::setw(2) << hours;
+      ss << ":";
+      ss << std::setfill('0') << std::setw(2) << minutes;
+      ss << ":";
+      ss << std::setfill('0') << std::setw(2) << seconds;
+
       LOG_INFO("LineID: " + std::to_string(sp.line_id()) +
                " Route: " + std::to_string(sp.route_index()) +
-               " Dep Time: " + std::to_string(sp.origin_departure_time()));
+               " Dep Time: " + ss.str());
     }
   }
 }


### PR DESCRIPTION
I added the ability to dump a transit schedule.  

Using the dump from the routes and departures, you can obtain the time and tripid that you are interested in looking at.  You do not need the destination.  If you do not provide the destination, the entire schedule from the stop provided to the end of the line is printed out.

New args:  -d (destination), -i (tripid), and -t (time) 

Example to dump from an origin to a destination.

./transit_stop_query -y 40.743326 -x -73.990005 -o s-dr5ru3006q-23st -d s-dr5rkjw7yq-carrollst -i 87215 -t 08:06:00 -c ./conf/valhalla.json

![image](https://cloud.githubusercontent.com/assets/2676277/12182618/34de02ec-b557-11e5-97aa-2a5ea86fd9db.png)

Example to dump the entire schedule.
./transit_stop_query -y 40.743326 -x -73.990005 -o s-dr5ru3006q-23st -i 87215 -t 08:06:00 -c ./conf/valhalla.json

![image](https://cloud.githubusercontent.com/assets/2676277/12182674/ac0271d2-b557-11e5-9d4c-f4c5d9e3d2a3.png)