### PR TITLE
Fix Graphenhancer use of cached tiles

### DIFF
--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -1224,7 +1224,7 @@ void enhance(const boost::property_tree::ptree& pt,
       }
 
       // Go through directed edges and "enhance" directed edge attributes
-      const DirectedEdge* edges = tile->directededge(nodeinfo.edge_index());
+      const DirectedEdge* edges = tilebuilder.directededges(nodeinfo.edge_index());
       for (uint32_t j = 0; j <  nodeinfo.edge_count(); j++) {
         DirectedEdge& directededge =
             tilebuilder.directededge_builder(nodeinfo.edge_index() + j);

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -637,6 +637,14 @@ DirectedEdge& GraphTileBuilder::directededge(const size_t idx) {
   throw std::runtime_error("GraphTile DirectedEdge id out of bounds");
 }
 
+// Gets a pointer to directed edges within the list being built.
+const DirectedEdge* GraphTileBuilder::directededges(const size_t idx) {
+  if (idx < header_->directededgecount())
+    return &directededges_builder_[idx];
+  throw std::runtime_error("GraphTile DirectedEdge id out of bounds");
+}
+
+
 // Get the directed edge builder at the specified index.
 DirectedEdge& GraphTileBuilder::directededge_builder(const size_t idx) {
   if (idx < header_->directededgecount())

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -226,11 +226,19 @@ class GraphTileBuilder : public baldr::GraphTile {
   NodeInfo& node_builder(const size_t idx);
 
   /**
-   * Gets a builder for a directed edge from existing tile data.
+   * Gets a directed edge from existing tile data.
    * @param  idx  Index of the directed edge within the tile.
-   * @return  Returns a reference to the directed edge builder.
+   * @return  Returns a reference to the directed edge.
    */
   DirectedEdge& directededge(const size_t idx);
+
+  /**
+   * Gets a pointer to directed edges within the list being built.
+   * @param  idx  Index of the directed edge within the tile.
+   * @return  Returns a pointer to the directed edge builder (allows
+   *          accessing all directed edges from a node).
+   */
+  const DirectedEdge* directededges(const size_t idx);
 
   /**
    * Get the directed edge builder at the specified index.


### PR DESCRIPTION
GraphEnhancer was using locally cached tiles in 2nd pass rather than those from the builder that have the link use changes. Fixes #313 and valhalla/sif#89