### PR TITLE
Fix bug in prior commit where header graphid is set to (0,0,0)

### DIFF
--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -34,12 +34,11 @@ GraphTileBuilder::GraphTileBuilder(const baldr::TileHierarchy& hierarchy,
     : GraphTile(hierarchy, graphid),
       hierarchy_(hierarchy) {
 
-  // Copy tile header to a builder (if tile exists)
+  // Copy tile header to a builder (if tile exists). Always set the tileid
   if (size_ > 0) {
     header_builder_ = *header_;
-  } else {
-    header_builder_.set_graphid(graphid);
   }
+  header_builder_.set_graphid(graphid);
 
   // Done if not deserializing and creating builders for everything
   if (!deserialize) {

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -36,7 +36,8 @@ GraphTileBuilder::GraphTileBuilder(const baldr::TileHierarchy& hierarchy,
 
   // Copy tile header to a builder (if tile exists)
   if (size_ > 0) {
-    header_builder_ = static_cast<GraphTileHeader&>(*(header_));
+    header_builder_ = *header_;
+  } else {
     header_builder_.set_graphid(graphid);
   }
 


### PR DESCRIPTION
when no current tile exists.