### PR TITLE
Rework TransitDepartures

### DIFF
--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -80,8 +80,8 @@ GraphTileBuilder::GraphTileBuilder(const baldr::TileHierarchy& hierarchy,
     text_offsets.insert(transit_routes_[i].long_name_offset());
     text_offsets.insert(transit_routes_[i].desc_offset());
   }
-  for (uint32_t i = 0; i < header_->transfercount(); i++) {
-    transfer_builder_.emplace_back(std::move(transit_transfers_[i]));
+  for (uint32_t i = 0; i < header_->schedulecount(); i++) {
+    schedule_builder_.emplace_back(std::move(transit_schedules_[i]));
   }
 
   // Create access restriction list
@@ -171,7 +171,7 @@ void GraphTileBuilder::StoreTileData() {
     header_builder_.set_departurecount(departure_builder_.size());
     header_builder_.set_stopcount(stop_builder_.size());
     header_builder_.set_routecount(route_builder_.size());
-    header_builder_.set_transfercount(transfer_builder_.size());
+    header_builder_.set_schedulecount(schedule_builder_.size());
     header_builder_.set_access_restriction_count(
                 access_restriction_builder_.size());
     header_builder_.set_signcount(signs_builder_.size());
@@ -183,7 +183,7 @@ void GraphTileBuilder::StoreTileData() {
             + (departure_builder_.size() * sizeof(TransitDeparture))
             + (stop_builder_.size() * sizeof(TransitStop))
             + (route_builder_.size() * sizeof(TransitRoute))
-            + (transfer_builder_.size() * sizeof(TransitTransfer))
+            + (schedule_builder_.size() * sizeof(TransitSchedule))
             + (access_restriction_builder_.size() * sizeof(AccessRestriction))
             + (signs_builder_.size() * sizeof(Sign))
             + (admins_builder_.size() * sizeof(Admin)));
@@ -216,10 +216,9 @@ void GraphTileBuilder::StoreTileData() {
     file.write(reinterpret_cast<const char*>(&route_builder_[0]),
                route_builder_.size() * sizeof(TransitRoute));
 
-    // Sort and write the transit transfers
-    std::sort(transfer_builder_.begin(), transfer_builder_.end());
-    file.write(reinterpret_cast<const char*>(&transfer_builder_[0]),
-               transfer_builder_.size() * sizeof(TransitTransfer));
+    // Write transit schedules
+    file.write(reinterpret_cast<const char*>(&schedule_builder_[0]),
+               schedule_builder_.size() * sizeof(TransitSchedule));
 
     // Sort and write the access restrictions
     std::sort(access_restriction_builder_.begin(), access_restriction_builder_.end());
@@ -296,9 +295,9 @@ void GraphTileBuilder::Update(
     file.write(reinterpret_cast<const char*>(&transit_routes_[0]),
         header_->routecount() * sizeof(TransitRoute));
 
-    // Write the existing transit transfers
-    file.write(reinterpret_cast<const char*>(&transit_transfers_[0]),
-        header_->transfercount() * sizeof(TransitTransfer));
+    // Write the existing transit schedules
+    file.write(reinterpret_cast<const char*>(&transit_schedules_[0]),
+        header_->schedulecount() * sizeof(TransitSchedule));
 
     // Write the existing access restrictions
     file.write(reinterpret_cast<const char*>(&access_restrictions_[0]),
@@ -371,9 +370,9 @@ void GraphTileBuilder::Update(const GraphTileHeader& hdr,
     file.write(reinterpret_cast<const char*>(&transit_routes_[0]),
                hdr.routecount() * sizeof(TransitRoute));
 
-    // Write the existing transit transfers
-    file.write(reinterpret_cast<const char*>(&transit_transfers_[0]),
-               hdr.transfercount() * sizeof(TransitTransfer));
+    // Write the existing transit schedules
+    file.write(reinterpret_cast<const char*>(&transit_schedules_[0]),
+               hdr.schedulecount() * sizeof(TransitSchedule));
 
     // Write the updated access restrictions
     file.write(reinterpret_cast<const char*>(&restrictions[0]),
@@ -432,9 +431,9 @@ void GraphTileBuilder::AddTransitRoute(const TransitRoute& route)  {
   route_builder_.emplace_back(std::move(route));
 }
 
-// Add a transit transfer.
-void GraphTileBuilder::AddTransitTransfer(const TransitTransfer& transfer)  {
-  transfer_builder_.emplace_back(std::move(transfer));
+// Add a transit schedule.
+void GraphTileBuilder::AddTransitSchedule(const TransitSchedule& schedule)  {
+  schedule_builder_.emplace_back(std::move(schedule));
 }
 
 // Add an access restriction.

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -508,8 +508,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder,
                 const std::vector<float> distances,
                 const std::vector<uint32_t>& route_types) {
   auto t1 = std::chrono::high_resolution_clock::now();
-LOG_INFO("Add transit to graph: TileID = " + std::to_string(tilebuilder.header()->graphid().tileid()) +
-        " size = " + std::to_string(tilebuilder.size()));
+
   // Move existing nodes and directed edge builder vectors and clear the lists
   std::vector<NodeInfo> currentnodes(std::move(tilebuilder.nodes()));
   uint32_t nodecount = currentnodes.size();
@@ -817,7 +816,7 @@ LOG_INFO("Add transit to graph: TileID = " + std::to_string(tilebuilder.header()
       uint32_t edge_info_offset = tilebuilder.AddEdgeInfo(transitedge.lineid,
            origin_node, endnode, 0, shape, names, added);
       directededge.set_edgeinfo_offset(edge_info_offset);
-      directededge.set_forward(true);
+      directededge.set_forward(added);
 
       // Add to list of directed edges
       tilebuilder.directededges().emplace_back(std::move(directededge));

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -9,6 +9,8 @@
 #include <vector>
 #include <queue>
 #include <unordered_map>
+#include <tuple>
+#include <set>
 #include <sqlite3.h>
 #include <spatialite.h>
 #include <fstream>
@@ -34,20 +36,18 @@ using namespace valhalla::mjolnir;
 namespace {
 
 struct Departure {
-  uint64_t days;
   GraphId  orig_pbf_graphid;   // GraphId in pbf tiles
   GraphId  dest_pbf_graphid;   // GraphId in pbf tiles
   uint32_t trip;
   uint32_t route;
   uint32_t blockid;
   uint32_t shapeid;
-  uint32_t end_day;
   uint32_t headsign_offset;
   uint32_t dep_time;
+  uint32_t schedule_index;
   float    orig_dist_traveled;
   float    dest_dist_traveled;
   uint16_t elapsed_time;
-  uint8_t  dow;
   bool     wheelchair_accessible;
 };
 
@@ -122,6 +122,10 @@ std::unordered_multimap<GraphId, Departure> ProcessStopPairs(
   // Check if there are no schedule stop pairs in this tile
   std::unordered_multimap<GraphId, Departure> departures;
   uint32_t tile_date = tilebuilder.header()->date_created();
+
+  // Map of unique schedules (validity) in this tile
+  uint32_t schedule_index = 0;
+  std::map<TransitSchedule, uint32_t> schedules;
 
   std::size_t slash_found = file.find_last_of("/\\");
   std::string directory = file.substr(0,slash_found);
@@ -205,7 +209,7 @@ std::unordered_multimap<GraphId, Departure> ProcessStopPairs(
           stop_access[dep.dest_pbf_graphid] = bikes_allowed;
 
           // Compute days of week mask
-          uint8_t dow_mask = kDOWNone;
+          uint32_t dow_mask = kDOWNone;
           for (uint32_t x = 0; x < sp.service_days_of_week_size(); x++) {
             bool dow = sp.service_days_of_week(x);
             if (dow) {
@@ -234,37 +238,50 @@ std::unordered_multimap<GraphId, Departure> ProcessStopPairs(
               }
             }
           }
-          dep.dow = dow_mask;
 
           // Compute the valid days
           // set the bits based on the dow.
           boost::gregorian::date start_date(boost::gregorian::gregorian_calendar::from_julian_day_number(sp.service_start_date()));
           boost::gregorian::date end_date(boost::gregorian::gregorian_calendar::from_julian_day_number(sp.service_end_date()));
-          dep.days = DateTime::get_service_days(start_date, end_date, tile_date, dow_mask);
+          uint64_t days = DateTime::get_service_days(start_date, end_date, tile_date, dow_mask);
 
           // if this is a service addition for one day, delete the dow_mask.
           if (sp.service_start_date() == sp.service_end_date())
-            dep.dow = kDOWNone;
+            dow_mask = kDOWNone;
 
           // if dep.days == 0 then feed either starts after the end_date or tile_header_date > end_date
-          if (dep.days == 0 && !sp.service_added_dates_size()) {
+          if (days == 0 && !sp.service_added_dates_size()) {
             LOG_DEBUG("Feed rejected!  Start date: " + to_iso_extended_string(start_date) + " End date: " + to_iso_extended_string(end_date));
             continue;
           }
 
           dep.headsign_offset = tilebuilder.AddName(sp.trip_headsign());
-          dep.end_day = (DateTime::days_from_pivot_date(end_date) - tile_date);
+          uint32_t end_day = (DateTime::days_from_pivot_date(end_date) - tile_date);
 
           //if subtractions are between start and end date then turn off bit.
           for (const auto& x : sp.service_except_dates()) {
             boost::gregorian::date d(boost::gregorian::gregorian_calendar::from_julian_day_number(x));
-            dep.days = DateTime::remove_service_day(dep.days, start_date, end_date, d);
+            days = DateTime::remove_service_day(days, start_date, end_date, d);
           }
 
           //if additions are between start and end date then turn on bit.
           for (const auto& x : sp.service_added_dates()) {
             boost::gregorian::date d(boost::gregorian::gregorian_calendar::from_julian_day_number(x));
-            dep.days = DateTime::add_service_day(dep.days, start_date, end_date, d);
+            days = DateTime::add_service_day(days, start_date, end_date, d);
+          }
+
+          TransitSchedule sched(days, dow_mask, end_day);
+          auto sched_itr = schedules.find(sched);
+          if (schedules.find(sched) == schedules.end()) {
+            // Not in the map - add a new transit schedule to the tile
+            tilebuilder.AddTransitSchedule(sched);
+
+            // Add to the map and increment the index
+            schedules[sched] = schedule_index;
+            dep.schedule_index = schedule_index;
+            schedule_index++;
+          } else {
+            dep.schedule_index = sched_itr->second;
           }
 
           // Add to the departures list
@@ -274,7 +291,8 @@ std::unordered_multimap<GraphId, Departure> ProcessStopPairs(
     }
   }
   LOG_INFO("Tile " + std::to_string(tile_id.tileid()) + ": added " +
-           std::to_string(departures.size()) + " departures");
+           std::to_string(departures.size()) + " departures" +
+           " schedules: " + std::to_string(schedules.size()));
   return departures;
 }
 
@@ -490,7 +508,8 @@ void AddToGraph(GraphTileBuilder& tilebuilder,
                 const std::vector<float> distances,
                 const std::vector<uint32_t>& route_types) {
   auto t1 = std::chrono::high_resolution_clock::now();
-
+LOG_INFO("Add transit to graph: TileID = " + std::to_string(tilebuilder.header()->graphid().tileid()) +
+        " size = " + std::to_string(tilebuilder.size()));
   // Move existing nodes and directed edge builder vectors and clear the lists
   std::vector<NodeInfo> currentnodes(std::move(tilebuilder.nodes()));
   uint32_t nodecount = currentnodes.size();
@@ -790,13 +809,15 @@ void AddToGraph(GraphTileBuilder& tilebuilder,
       else if (transitedge.shapeid != 0)
         LOG_WARN("Shape Id not found: " + std::to_string(transitedge.shapeid));
 
-      auto shape = GetShape(stopll, endll,transitedge.shapeid, transitedge.orig_dist_traveled,
+      // TODO - how to share shape between 2 different stop Ids and routes
+      // but in different directions? For now use the line Id, which will not
+      // share edge info or shape
+      auto shape = GetShape(stopll, endll, transitedge.shapeid, transitedge.orig_dist_traveled,
                             transitedge.dest_dist_traveled, points, distance);
-      uint32_t edge_info_offset = tilebuilder.AddEdgeInfo(transitedge.routeid,
+      uint32_t edge_info_offset = tilebuilder.AddEdgeInfo(transitedge.lineid,
            origin_node, endnode, 0, shape, names, added);
-
       directededge.set_edgeinfo_offset(edge_info_offset);
-      directededge.set_forward(added);
+      directededge.set_forward(true);
 
       // Add to list of directed edges
       tilebuilder.directededges().emplace_back(std::move(directededge));
@@ -1143,8 +1164,21 @@ void build(const std::string& transit_dir,
         stopedges.intrastation.push_back(stop.parent);
       } **/
 
-      // Find unique transit graph edges.
-      std::map<std::pair<uint32_t, GraphId>, uint32_t> unique_transit_edges;
+      // Find unique transit graph edges. Use route Id, headsign offset,
+      // and end node graph Id to form a unique line Id / directed edge.
+      using key_t = std::tuple<uint32_t, uint32_t, GraphId>;
+      auto sorter = [](const key_t& t1, const key_t& t2) {
+        if (std::get<0>(t1) == std::get<0>(t2)) {
+          if (std::get<1>(t1) == std::get<1>(t2)) {
+            return std::get<2>(t1) < std::get<2>(t2);
+          } else {
+            return std::get<1>(t1) <std::get<1>(t2);
+          }
+        } else {
+          return std::get<0>(t1) == std::get<0>(t2);
+        }
+      };
+      std::map<key_t, uint32_t, std::function<bool (const key_t&, const key_t&)> > unique_transit_edges(sorter);
       auto range = departures.equal_range(stop_pbf_graphid);
       for(auto key = range.first; key != range.second; ++key) {
         Departure dep = key->second;
@@ -1152,14 +1186,16 @@ void build(const std::string& transit_dir,
         // Identify unique route and arrival stop pairs - associate to a
         // unique line Id stored in the directed edge.
         uint32_t lineid;
-        auto m = unique_transit_edges.find({dep.route, dep.dest_pbf_graphid});
+        key_t tpl = std::make_tuple(dep.route, dep.headsign_offset, dep.dest_pbf_graphid);
+        auto m = unique_transit_edges.find(tpl);
         if (m == unique_transit_edges.end()) {
           // Add to the map and update the line id
           lineid = unique_lineid;
-          unique_transit_edges[{dep.route, dep.dest_pbf_graphid}] = unique_lineid;
+          unique_transit_edges[tpl] = unique_lineid;
           unique_lineid++;
           stopedges.lines.emplace_back(TransitLine{lineid, dep.route,
-                      dep.dest_pbf_graphid, dep.shapeid, dep.orig_dist_traveled, dep.dest_dist_traveled});
+                dep.dest_pbf_graphid, dep.shapeid, dep.orig_dist_traveled,
+                dep.dest_dist_traveled});
         } else {
           lineid = m->second;
         }
@@ -1167,7 +1203,7 @@ void build(const std::string& transit_dir,
         // Form transit departures
         TransitDeparture td(lineid, dep.trip, dep.route,
                     dep.blockid, dep.headsign_offset, dep.dep_time,
-                    dep.elapsed_time, dep.end_day, dep.dow, dep.days);
+                    dep.elapsed_time, dep.schedule_index);
 
 /*        LOG_DEBUG("Add departure: " + std::to_string(lineid) +
                      " dep time = " + std::to_string(td.departure_time()) +

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -56,7 +56,7 @@ bool tile_equalish(const GraphTile a, const GraphTile b, size_t difference, cons
      ah->speed_quality() == bh->speed_quality() &&
      ah->stopcount() == bh->stopcount() &&
      ah->textlist_offset() + difference== bh->textlist_offset() &&
-     ah->transfercount() == bh->transfercount() &&
+     ah->schedulecount() == bh->schedulecount() &&
      ah->version() ==  bh->version()) {
     //make sure the edges' shape and names match
     for(size_t i = 0; i < ah->directededgecount(); ++i) {

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -21,8 +21,8 @@
 #include <valhalla/baldr/signinfo.h>
 #include <valhalla/baldr/transitdeparture.h>
 #include <valhalla/baldr/transitroute.h>
+#include <valhalla/baldr/transitschedule.h>
 #include <valhalla/baldr/transitstop.h>
-#include <valhalla/baldr/transittransfer.h>
 #include <valhalla/baldr/tilehierarchy.h>
 
 #include <valhalla/mjolnir/directededgebuilder.h>
@@ -119,10 +119,10 @@ class GraphTileBuilder : public baldr::GraphTile {
   void AddTransitRoute(const baldr::TransitRoute& route);
 
   /**
-   * Add a transit transfer.
-   * @param  transfer  Transit transfer record.
+   * Add a transit schedule.
+   * @param  schedule  Transit schedule record.
    */
-  void AddTransitTransfer(const baldr::TransitTransfer& transfer);
+  void AddTransitSchedule(const baldr::TransitSchedule& schedule);
 
   /**
    * Add an access restriction.
@@ -352,14 +352,14 @@ class GraphTileBuilder : public baldr::GraphTile {
   // departure time
   std::vector<baldr::TransitDeparture> departure_builder_;
 
-  // Transit stops. Sorted by stop Id.
+  // Transit stops.
   std::vector<baldr::TransitStop> stop_builder_;
 
-  // Transit route. Sorted by route Id.
+  // Transit route.
   std::vector<baldr::TransitRoute> route_builder_;
 
-  // Transit transfers. Sorted by from stop Id.
-  std::vector<baldr::TransitTransfer> transfer_builder_;
+  // Transit schedules.
+  std::vector<baldr::TransitSchedule> schedule_builder_;
 
   // List of restrictions. Sorted by directed edge Id
   std::vector<baldr::AccessRestriction> access_restriction_builder_;


### PR DESCRIPTION
Separate schedules from departures. Find unique schedule validity records and add to the tile. Replace transfers with schedules in tile builder. Use line Id as the  edge Id since now there can be more than 1 transit edge between 2 stops with the same route Id. Use headsign in addition to route Id and end stop when forming unique edges. This is so 2 different trips on the same route are separated when one goes to the end of the line and the other does not (for example).