### PR TITLE
Pad EdgeInfo output (and SizeOf) to 8 byte boundaries

### DIFF
--- a/src/mjolnir/edgeinfobuilder.cc
+++ b/src/mjolnir/edgeinfobuilder.cc
@@ -101,9 +101,9 @@ std::ostream& operator<<(std::ostream& os, const EdgeInfoBuilder& eib) {
   // Pad to an 8 byte boundary
   std::size_t n = (eib.BaseSizeOf() % 8);
   if (n != 0) {
-	for (std::size_t i = 0; i < 8 - n; i++) {
-	  os << static_cast<char>(0);
-	}
+    for (std::size_t i = 0; i < 8 - n; i++) {
+      os << static_cast<char>(0);
+    }
   }
   return os;
 }

--- a/src/mjolnir/edgeinfobuilder.cc
+++ b/src/mjolnir/edgeinfobuilder.cc
@@ -66,7 +66,7 @@ std::size_t EdgeInfoBuilder::SizeOf() const {
   // Add padding to get to 8 byte boundaries
   size_t n = size % 8;
   if (n != 0) {
-	  size += 8 - n;
+    size += 8 - n;
   }
   return size;
 }

--- a/src/mjolnir/edgeinfobuilder.cc
+++ b/src/mjolnir/edgeinfobuilder.cc
@@ -51,11 +51,23 @@ void EdgeInfoBuilder::set_encoded_shape(const std::string& encoded_shape) {
 }
 
 // Get the size of the edge info (including name offsets and shape string)
-std::size_t EdgeInfoBuilder::SizeOf() const {
+std::size_t EdgeInfoBuilder::BaseSizeOf() const {
   std::size_t size = sizeof(uint64_t);
   size += sizeof(baldr::EdgeInfo::PackedItem);
   size += (text_name_offset_list_.size() * sizeof(uint32_t));
   size += (encoded_shape_.size() * sizeof(std::string::value_type));
+  return size;
+}
+
+// Get the size of the edge info (including name offsets and shape string)
+std::size_t EdgeInfoBuilder::SizeOf() const {
+  std::size_t size = BaseSizeOf();
+
+  // Add padding to get to 8 byte boundaries
+  size_t n = size % 8;
+  if (n != 0) {
+	  size += 8 - n;
+  }
   return size;
 }
 
@@ -86,6 +98,13 @@ std::ostream& operator<<(std::ostream& os, const EdgeInfoBuilder& eib) {
             (name_count * sizeof(uint32_t)));
   os << eib.encoded_shape_;
 
+  // Pad to an 8 byte boundary
+  std::size_t n = (eib.BaseSizeOf() % 8);
+  if (n != 0) {
+	for (std::size_t i = 0; i < 8 - n; i++) {
+	  os << static_cast<char>(0);
+	}
+  }
   return os;
 }
 

--- a/valhalla/mjolnir/edgeinfobuilder.h
+++ b/valhalla/mjolnir/edgeinfobuilder.h
@@ -55,7 +55,14 @@ class EdgeInfoBuilder {
   void set_encoded_shape(const std::string& encoded_shape);
 
   /**
-   * Get the size of this edge info.
+   * Get the size of this edge info (without padding).
+   * @return  Returns the size in bytes of this object.
+   */
+  std::size_t BaseSizeOf() const;
+
+  /**
+   * Get the size of this edge info. Includes padding to align to
+   * 8-byte boundaries.
    * @return  Returns the size in bytes of this object.
    */
   std::size_t SizeOf() const;


### PR DESCRIPTION
so each way Id (uint64_t) starts on an 8 byte boundary.