### PR TITLE
Fetcher builder updates

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,6 @@ set -e
 
 export LD_LIBRARY_PATH=.:`cat /etc/ld.so.conf.d/* | grep -v -E "#" | tr "\\n" ":" | sed -e "s/:$//g"`
 ./autogen.sh
-./configure --enable-coverage CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE
+./configure --enable-coverage CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS"
 make test -j$(nproc)
 sudo make install

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -107,7 +107,7 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode, DirectedEdge& edge,
     // transit edges and wayid matching
     if (startnode.level() == 2) {
       if (edge.use() == Use::kTransitConnection && directededge->use() == Use::kTransitConnection) {
-        if (edge.lineid() == directededge->lineid()) {
+        if (tile->edgeinfo(edge.edgeinfo_offset())->wayid() == end_tile->edgeinfo(directededge->edgeinfo_offset())->wayid()) {
           opp_index = i;
         }
       }
@@ -168,7 +168,7 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode, DirectedEdge& edge,
         }
       }
       if (edge.use() == Use::kTransitConnection && directededge->use() == Use::kTransitConnection) {
-        if (edge.lineid() == directededge->lineid()) {
+        if (tile->edgeinfo(edge.edgeinfo_offset())->wayid() == end_tile->edgeinfo(directededge->edgeinfo_offset())->wayid()) {
           opp_index = i;
         }
       }

--- a/src/mjolnir/transit_fetcher.cc
+++ b/src/mjolnir/transit_fetcher.cc
@@ -1281,10 +1281,6 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
     node.set_edge_index(tilebuilder_transit.directededges().size());
     node.set_timezone(stop.timezone());
 
-    bool admin_set = false;
-
-//TODO - admin lookup
-
  /** TODO - future when we get egress, station, platform hierarchy
     // Add any intra-station connections - these are always in the same tile?
     for (const auto& endstopid : stop_edges.second.intrastation) {

--- a/src/mjolnir/transit_fetcher.cc
+++ b/src/mjolnir/transit_fetcher.cc
@@ -23,14 +23,75 @@
 #include <valhalla/baldr/tilehierarchy.h>
 #include <valhalla/baldr/graphtile.h>
 #include <valhalla/baldr/datetime.h>
+#include <valhalla/baldr/graphreader.h>
 #include <valhalla/midgard/util.h>
 
+#include "mjolnir/graphtilebuilder.h"
 #include "proto/transit.pb.h"
 
 using namespace boost::property_tree;
 using namespace valhalla::midgard;
 using namespace valhalla::baldr;
 using namespace valhalla::mjolnir;
+
+// Shape
+struct Shape {
+  uint32_t begins;
+  uint32_t ends;
+  std::vector<PointLL> shape;
+};
+
+struct Departure {
+  GraphId  orig_pbf_graphid;   // GraphId in pbf tiles
+  GraphId  dest_pbf_graphid;   // GraphId in pbf tiles
+  uint32_t trip;
+  uint32_t route;
+  uint32_t blockid;
+  uint32_t shapeid;
+  uint32_t headsign_offset;
+  uint32_t dep_time;
+  uint32_t schedule_index;
+  float    orig_dist_traveled;
+  float    dest_dist_traveled;
+  uint16_t elapsed_time;
+  bool     wheelchair_accessible;
+};
+
+// Unique route and stop
+struct TransitLine {
+  uint32_t lineid;
+  uint32_t routeid;
+  GraphId  dest_pbf_graphid;  // GraphId (from pbf) of the destination stop
+  uint32_t shapeid;
+  float    orig_dist_traveled;
+  float    dest_dist_traveled;
+};
+
+struct StopEdges {
+  GraphId origin_pbf_graphid;        // GraphId (from pbf) of the origin stop
+  std::vector<GraphId> intrastation; // List of intra-station connections
+  std::vector<TransitLine> lines;    // Set of unique route/stop pairs
+};
+
+// Struct to hold stats information during each threads work
+struct builder_stats {
+  uint32_t no_dir_edge_count;
+
+  // Accumulate stats from all threads
+  void operator()(const builder_stats& other) {
+    no_dir_edge_count += other.no_dir_edge_count;
+  }
+};
+
+GraphId TransitToTile(const boost::property_tree::ptree& pt, const std::string& transit_tile) {
+  auto tile_dir = pt.get<std::string>("mjolnir.tile_dir");
+  auto transit_dir = pt.get<std::string>("mjolnir.transit_dir");
+  auto graph_tile = tile_dir + transit_tile.substr(transit_dir.size());
+  boost::algorithm::trim_if(graph_tile, boost::is_any_of(".pbf"));
+  graph_tile += ".gph";
+  TileHierarchy hierarchy(tile_dir);
+  return GraphTile::GetTileId(graph_tile, hierarchy);
+}
 
 struct logged_error_t: public std::runtime_error {
   logged_error_t(const std::string& msg):std::runtime_error(msg) {
@@ -816,6 +877,838 @@ void stitch(const ptree& pt, const std::unordered_set<GraphId>& all_tiles, std::
   LOG_INFO("Finished");
 }
 
+// Get scheduled departures for a stop
+std::unordered_multimap<GraphId, Departure> ProcessStopPairs(
+    GraphTileBuilder& transit_tilebuilder,
+    const uint32_t tile_date,
+    const Transit& transit,
+    std::unordered_map<GraphId, bool>& stop_access,
+    const std::string& file,
+    const GraphId& tile_id, std::mutex& lock) {
+  // Check if there are no schedule stop pairs in this tile
+  std::unordered_multimap<GraphId, Departure> departures;
+
+  // Map of unique schedules (validity) in this tile
+  uint32_t schedule_index = 0;
+  std::map<TransitSchedule, uint32_t> schedules;
+
+  std::size_t slash_found = file.find_last_of("/\\");
+  std::string directory = file.substr(0,slash_found);
+
+  boost::filesystem::recursive_directory_iterator transit_file_itr(directory);
+  boost::filesystem::recursive_directory_iterator end_file_itr;
+
+  //for each tile.
+  for(; transit_file_itr != end_file_itr; ++transit_file_itr) {
+    if(boost::filesystem::is_regular(transit_file_itr->path())) {
+      std::string fname = transit_file_itr->path().string();
+      std::string ext = transit_file_itr->path().extension().string();
+      std::string file_name = fname.substr(0, fname.size() - ext.size());
+
+      // make sure we are looking at a pbf file
+      if ((ext == ".pbf" && fname == file) ||
+          (file_name.substr(file_name.size()-4) == ".pbf" && file_name == file)) {
+
+        Transit spp; {
+          // already loaded
+          if (ext == ".pbf")
+            spp = transit;
+          else
+            spp = read_pbf(fname, lock);
+        }
+
+        if (spp.stop_pairs_size() == 0) {
+          if (transit.stops_size() > 0) {
+            LOG_ERROR("Tile " + fname +
+                      " has 0 schedule stop pairs but has " +
+                      std::to_string(transit.stops_size()) + " stops");
+          }
+          departures.clear();
+          return departures;
+        }
+
+        // Iterate through the stop pairs in this tile and form Valhalla departure
+        // records
+        for (const auto& sp : spp.stop_pairs()) {
+          // We do not know in this step if the end node is in a valid (non-empty)
+          // Valhalla tile. So just add the stop pair and we will address this later
+
+          // Use transit PBF graph Ids internally until adding to the graph tiles
+          // TODO - wheelchair accessible, shape information
+          Departure dep;
+          dep.orig_pbf_graphid = GraphId(sp.origin_graphid());
+          dep.dest_pbf_graphid = GraphId(sp.destination_graphid());
+          dep.route = sp.route_index();
+          dep.trip = sp.trip_id();
+
+          // if we have shape data then set everything else shapeid = 0;
+          if (sp.has_shape_id() && sp.has_destination_dist_traveled() && sp.has_origin_dist_traveled()) {
+            dep.shapeid = sp.shape_id();
+            dep.orig_dist_traveled = sp.origin_dist_traveled();
+            dep.dest_dist_traveled = sp.destination_dist_traveled();
+          } else dep.shapeid = 0;
+
+          dep.blockid = sp.has_block_id() ? sp.block_id() : 0;
+          dep.dep_time = sp.origin_departure_time();
+          dep.elapsed_time = sp.destination_arrival_time() - dep.dep_time;
+
+          // Set bikes_allowed on the stops
+          // TODO - should this be |= ???
+          bool bikes_allowed = sp.bikes_allowed();
+          stop_access[dep.orig_pbf_graphid] = bikes_allowed;
+          stop_access[dep.dest_pbf_graphid] = bikes_allowed;
+
+          // Compute days of week mask
+          uint32_t dow_mask = kDOWNone;
+          for (uint32_t x = 0; x < sp.service_days_of_week_size(); x++) {
+            bool dow = sp.service_days_of_week(x);
+            if (dow) {
+              switch (x) {
+                case 0:
+                  dow_mask |= kMonday;
+                  break;
+                case 1:
+                  dow_mask |= kTuesday;
+                  break;
+                case 2:
+                  dow_mask |= kWednesday;
+                  break;
+                case 3:
+                  dow_mask |= kThursday;
+                  break;
+                case 4:
+                  dow_mask |= kFriday;
+                  break;
+                case 5:
+                  dow_mask |= kSaturday;
+                  break;
+                case 6:
+                  dow_mask |= kSunday;
+                  break;
+              }
+            }
+          }
+
+          // Compute the valid days
+          // set the bits based on the dow.
+          boost::gregorian::date start_date(boost::gregorian::gregorian_calendar::from_julian_day_number(sp.service_start_date()));
+          boost::gregorian::date end_date(boost::gregorian::gregorian_calendar::from_julian_day_number(sp.service_end_date()));
+          uint64_t days = DateTime::get_service_days(start_date, end_date, tile_date, dow_mask);
+
+          // if this is a service addition for one day, delete the dow_mask.
+          if (sp.service_start_date() == sp.service_end_date())
+            dow_mask = kDOWNone;
+
+          // if dep.days == 0 then feed either starts after the end_date or tile_header_date > end_date
+          if (days == 0 && !sp.service_added_dates_size()) {
+            LOG_DEBUG("Feed rejected!  Start date: " + to_iso_extended_string(start_date) + " End date: " + to_iso_extended_string(end_date));
+            continue;
+          }
+
+          dep.headsign_offset = transit_tilebuilder.AddName(sp.trip_headsign());
+          uint32_t end_day = (DateTime::days_from_pivot_date(end_date) - tile_date);
+
+          //if subtractions are between start and end date then turn off bit.
+          for (const auto& x : sp.service_except_dates()) {
+            boost::gregorian::date d(boost::gregorian::gregorian_calendar::from_julian_day_number(x));
+            days = DateTime::remove_service_day(days, start_date, end_date, d);
+          }
+
+          //if additions are between start and end date then turn on bit.
+          for (const auto& x : sp.service_added_dates()) {
+            boost::gregorian::date d(boost::gregorian::gregorian_calendar::from_julian_day_number(x));
+            days = DateTime::add_service_day(days, start_date, end_date, d);
+          }
+
+          TransitSchedule sched(days, dow_mask, end_day);
+          auto sched_itr = schedules.find(sched);
+          if (sched_itr == schedules.end()) {
+            // Not in the map - add a new transit schedule to the tile
+            transit_tilebuilder.AddTransitSchedule(sched);
+
+            // Add to the map and increment the index
+            schedules[sched] = schedule_index;
+            dep.schedule_index = schedule_index;
+            schedule_index++;
+          } else {
+            dep.schedule_index = sched_itr->second;
+          }
+
+          // Add to the departures list
+          departures.emplace(dep.orig_pbf_graphid, std::move(dep));
+        }
+      }
+    }
+  }
+  LOG_INFO("Tile " + std::to_string(tile_id.tileid()) + ": added " +
+           std::to_string(departures.size()) + " departures" +
+           " schedules: " + std::to_string(schedules.size()));
+  return departures;
+}
+
+// Add routes to the tile. Return a vector of route types.
+std::vector<uint32_t> AddRoutes(const Transit& transit,
+                   GraphTileBuilder& tilebuilder) {
+  // Route types vs. index
+  std::vector<uint32_t> route_types;
+
+  for (uint32_t i = 0; i < transit.routes_size(); i++) {
+    const Transit_Route& r = transit.routes(i);
+
+      // These should all be correctly set in the fetcher as it tosses types that we
+      // don't support.  However, let's report an error if we encounter one.
+      switch (static_cast<TransitType>(r.vehicle_type())) {
+        case TransitType::kTram:        // Tram, streetcar, lightrail
+        case TransitType::kMetro:      // Subway, metro
+        case TransitType::kRail:        // Rail
+        case TransitType::kBus:         // Bus
+        case TransitType::kFerry:       // Ferry
+        case TransitType::kCableCar:    // Cable car
+        case TransitType::kGondola:     // Gondola (suspended cable car)
+        case TransitType::kFunicular:   // Funicular (steep incline)
+          break;
+        default:
+          LOG_ERROR("Unsupported vehicle type!");
+          break;
+      }
+
+      TransitRoute route(r.vehicle_type(),
+                         tilebuilder.AddName(r.onestop_id()),
+                         tilebuilder.AddName(r.operated_by_onestop_id()),
+                         tilebuilder.AddName(r.operated_by_name()),
+                         tilebuilder.AddName(r.operated_by_website()),
+                         r.route_color(),
+                         r.route_text_color(),
+                         tilebuilder.AddName(r.name()),
+                         tilebuilder.AddName(r.route_long_name()),
+                         tilebuilder.AddName(r.route_desc()));
+      LOG_DEBUG("Route idx = " + std::to_string(i) + ": " + r.name() + ","
+                     + r.route_long_name());
+      tilebuilder.AddTransitRoute(route);
+
+      // Route type - need this to store in edge.
+      route_types.push_back(r.vehicle_type());
+  }
+  return route_types;
+}
+
+// Get Use given the transit route type
+// TODO - add separate Use for different types - when we do this change
+// the directed edge IsTransit method
+Use GetTransitUse(const uint32_t rt) {
+  switch (static_cast<TransitType>(rt)) {
+    default:
+  case TransitType::kTram:        // Tram, streetcar, lightrail
+  case TransitType::kMetro:      // Subway, metro
+  case TransitType::kRail:        // Rail
+  case TransitType::kCableCar:    // Cable car
+  case TransitType::kGondola:     // Gondola (suspended cable car)
+  case TransitType::kFunicular:   // Funicular (steep incline)
+    return Use::kRail;
+  case TransitType::kBus:         // Bus
+    return Use::kBus;
+  case TransitType::kFerry:       // Ferry (boat)
+    return Use::kRail;            // TODO - add ferry use
+  }
+}
+
+std::list<PointLL> GetShape(const PointLL& stop_ll, const PointLL& endstop_ll, uint32_t shapeid,
+                            const float orig_dist_traveled, const float dest_dist_traveled,
+                            const std::vector<PointLL>& trip_shape, const std::vector<float>& distances) {
+  std::list<PointLL> shape;
+  if (shapeid != 0 && trip_shape.size() && stop_ll != endstop_ll &&
+      orig_dist_traveled < dest_dist_traveled) {
+
+    float distance = 0.0f, d_from_p0_to_x = 0.0f;
+
+    // point x - we are trying to find it on the line segment between p0 and p1
+    PointLL x;
+    // find out where orig_dist_traveled should be in the list.
+    auto lower_bound = std::lower_bound(distances.cbegin(), distances.cend(), orig_dist_traveled);
+    // find out where dest_dist_traveled should be in the list.
+    auto upper_bound = std::upper_bound(distances.cbegin(), distances.cend(), dest_dist_traveled);
+    float prev_distance = *(lower_bound);
+
+    // distance calculations can be off just a bit (i.e., 9372.224609 < 9372.500000) so set it to
+    // the last element.
+    if (distances.back() < dest_dist_traveled)
+      upper_bound = distances.cend()-1;
+
+    // lower_bound returns an iterator pointing to the first element which does not compare less than the dist_traveled;
+    // therefore, we need to back up one if it does not equal the lower_bound value.  For example, we could be starting
+    // at the beginning of the points list
+    if (orig_dist_traveled != (*lower_bound))
+      prev_distance = *(--lower_bound);
+
+    // loop through the points.
+    for (auto itr = lower_bound; itr != upper_bound; ++itr) {
+
+      /*    |
+       *    |
+       *    p0
+       *    | }--d_from_p0_to_x (distance from p0 to x)
+       *    x -- point we are trying to find on the segment (orig_dist_traveled or dest_dist_traveled on this segment)
+       *    |
+       *    |
+       *    |
+       *    |
+       *    p1
+       *    |
+       *    |
+       */
+
+      // index into our vector of points
+      uint32_t index = (itr - distances.cbegin());
+      PointLL p0 = trip_shape[index];
+      PointLL p1 = trip_shape[index + 1];
+
+      // this is our distance that is beyond x.
+      distance = *(itr+1);
+
+      // find point x using the orig_dist_traveled - this is our first point added to shape
+      if (itr == lower_bound) {
+        if (orig_dist_traveled == *itr) // just add p0
+          shape.push_back(p0);
+        else {
+          // distance from p0 to x using the orig_dist_traveled
+          d_from_p0_to_x = (orig_dist_traveled - prev_distance) / (distance - prev_distance);
+          x = p0 + (p1 - p0) * d_from_p0_to_x;
+          shape.push_back(x);
+        }
+      }
+
+      // find point x using the dest_dist_traveled - this is our last point added to the shape
+      if ((itr+1) == upper_bound) {
+        if (dest_dist_traveled == *itr) { // just add p0
+          if (shape.back() != p0) //avoid dups
+            shape.push_back(p0);
+        } else {
+          // distance from p0 to x using the dest_dist_traveled
+          d_from_p0_to_x = (dest_dist_traveled - prev_distance) / (distance - prev_distance);
+          x = p0 + (p1 - p0) * d_from_p0_to_x;
+
+          if (shape.back() != x) //avoid dups
+            shape.push_back(x);
+          // we are done p1 is too far away
+        }
+        break;
+      }
+      // add all the midpoints.
+      shape.push_back(p1);
+
+      prev_distance = distance;
+    }
+  // else no shape exists.
+  } else {
+    shape.push_back(stop_ll);
+    shape.push_back(endstop_ll);
+  }
+
+  return shape;
+}
+
+// Converts a stop's pbf graph Id to a Valhalla graph Id by adding the
+// tile's node count. Returns an Invalid GraphId if the tile is not found
+// in the list of Valhalla tiles
+GraphId GetGraphId(const GraphId& nodeid,
+                   const std::unordered_set<GraphId>& all_tiles) {
+  auto t = all_tiles.find(nodeid.Tile_Base());
+  if (t == all_tiles.end()) {
+    return GraphId();  // Invalid graph Id
+  } else {
+    return { nodeid.tileid(), nodeid.level()+1, nodeid.id()};
+  }
+}
+
+void AddToGraph(GraphTileBuilder& tilebuilder_transit,
+                const TileHierarchy& hierarchy_transit,
+                const GraphId& tileid,
+                const std::string& tile,
+                const std::string& transit_dir,
+                std::mutex& lock,
+                const std::unordered_set<GraphId>& all_tiles,
+                const std::map<GraphId, StopEdges>& stop_edge_map,
+                const std::unordered_map<GraphId, bool>& stop_access,
+                const std::unordered_map<uint32_t, Shape> shape_data,
+                const std::vector<float> distances,
+                const std::vector<uint32_t>& route_types,
+                uint32_t& no_dir_edge_count) {
+  auto t1 = std::chrono::high_resolution_clock::now();
+
+  // Get Transit PBF data for this tile
+  Transit transit = read_pbf(tile, lock);
+
+  tilebuilder_transit.AddAdmin("None","None","","");
+
+  // Iterate through the stops and their edges
+  uint32_t nadded = 0;
+  uint32_t transitedges = 0;
+  for (const auto& stop_edges : stop_edge_map) {
+    // Get the stop information
+    GraphId stopid = stop_edges.second.origin_pbf_graphid;
+    uint32_t stop_index = stopid.id();
+    const Transit_Stop& stop = transit.stops(stop_index);
+    if (GraphId(stop.graphid()) != stopid) {
+      LOG_ERROR("Stop key not equal!");
+    }
+
+    LOG_DEBUG("Transit Stop: " + stop.name() + " stop index= " +
+              std::to_string(stop_index));
+
+    // Get the Valhalla graphId of the origin node (transit stop)
+    GraphId origin_node = GetGraphId(stopid, all_tiles);
+
+    // Build the node info. Use generic transit stop type
+    uint32_t access = kPedestrianAccess;
+    /** TODO bicycle access
+    auto s_access = stop_access.find(stop.pbf_graphid);
+    if (s_access != stop_access.end()) {
+      if (s_access->second)
+        access |= kBicycleAccess;
+    }
+    **/
+
+    // TODO - parent/child flags
+    bool child  = false; // (stop.parent.Is_Valid());  // TODO verify if this is sufficient
+    bool parent = false; // (stop.type == 1);          // TODO verify if this is sufficient
+    PointLL stopll = { stop.lon(), stop.lat() };
+    NodeInfo node(stopll, RoadClass::kServiceOther, access,
+                        NodeType::kMultiUseTransitStop, false);
+    node.set_child(child);
+    node.set_parent(parent);
+    node.set_mode_change(true);
+    node.set_stop_index(stop_index);
+    node.set_edge_index(tilebuilder_transit.directededges().size());
+    node.set_timezone(stop.timezone());
+
+    bool admin_set = false;
+
+//TODO - admin lookup
+
+ /** TODO - future when we get egress, station, platform hierarchy
+    // Add any intra-station connections - these are always in the same tile?
+    for (const auto& endstopid : stop_edges.second.intrastation) {
+
+      const Stop& endstop = stops[endstopid.id()];
+      if (endstopid != endstop.pbf_graphid) {
+        LOG_ERROR("End stop key not equal");
+      }
+
+      GraphId endnode = GetGraphId(endstop.pbf_graphid);
+      if (!endnode.Is_Valid()) {
+        continue;
+      }
+
+      DirectedEdge directededge;
+      directededge.set_endnode(endstop.pbf_graphid);
+
+      // Make sure length is non-zero
+      float length = std::max(1.0f, stop.ll().Distance(endstop.ll()));
+      directededge.set_length(length);
+      directededge.set_use(Use::kTransitConnection);
+      directededge.set_speed(5);
+      directededge.set_classification(RoadClass::kServiceOther);
+      directededge.set_localedgeidx(tilebuilder.directededges().size() - node.edge_index());
+      directededge.set_forwardaccess(kPedestrianAccess);  // TODO - bikes?
+      directededge.set_reverseaccess(kPedestrianAccess);  // TODO - bikes?
+
+      LOG_DEBUG("Add parent/child directededge - endnode stop id = " +
+               std::to_string(endstop.key) + " GraphId: " +
+               std::to_string(endstop.graphid.tileid()) + "," +
+               std::to_string(endstop.graphid.id()));
+
+      // Add edge info to the tile and set the offset in the directed edge
+      bool added = false;
+      std::vector<std::string> names;
+      std::list<PointLL> shape = { stop.ll(), endstop.ll() };
+
+      // TODO - these need to be valhalla graph Ids
+      uint32_t edge_info_offset = tilebuilder.AddEdgeInfo(0, stop.pbf_graphid,
+                     endstop.pbf_graphid, 0, shape, names, added);
+      directededge.set_edgeinfo_offset(edge_info_offset);
+      directededge.set_forward(added);
+
+      // Add to list of directed edges
+      tilebuilder.directededges().emplace_back(std::move(directededge));
+    }
+**/
+
+    // Add transit lines
+    // level 3
+    for (const auto& transitedge : stop_edges.second.lines) {
+      // Get the end node. Skip this directed edge if the Valhalla tile is
+      // not valid (or empty)
+      GraphId endnode = GetGraphId(transitedge.dest_pbf_graphid, all_tiles);
+      if (!endnode.Is_Valid()) {
+        continue;
+      }
+
+      // Find the lat,lng of the end stop
+      PointLL endll;
+      std::string endstopname;
+      GraphId end_stop_graphid = transitedge.dest_pbf_graphid;
+
+      if (end_stop_graphid.Tile_Base() == tileid) {
+        // End stop is in the same pbf transit tile
+        const Transit_Stop& endstop = transit.stops(end_stop_graphid.id());
+        endstopname = endstop.name();
+        endll = {endstop.lon(), endstop.lat()};
+      } else {
+        // Get Transit PBF data for this tile
+        // Get transit pbf tile
+        std::string file_name = GraphTile::FileSuffix(GraphId(end_stop_graphid.tileid(), end_stop_graphid.level(),0), hierarchy_transit);
+        boost::algorithm::trim_if(file_name, boost::is_any_of(".gph"));
+        file_name += ".pbf";
+        const std::string file = transit_dir + '/' + file_name;
+        Transit endtransit = read_pbf(file, lock);
+        const Transit_Stop& endstop = endtransit.stops(end_stop_graphid.id());
+        endstopname = endstop.name();
+        endll = {endstop.lon(), endstop.lat()};
+      }
+
+      // Add the directed edge
+      DirectedEdge directededge;
+      directededge.set_endnode(endnode);
+      directededge.set_length(stopll.Distance(endll));
+      Use use = GetTransitUse(route_types[transitedge.routeid]);
+      directededge.set_use(use);
+      directededge.set_speed(5);
+      directededge.set_classification(RoadClass::kServiceOther);
+      directededge.set_localedgeidx(tilebuilder_transit.directededges().size() - node.edge_index());
+      directededge.set_forwardaccess(kPedestrianAccess);  // TODO - bikes?
+      directededge.set_reverseaccess(kPedestrianAccess);  // TODO - bikes?
+      directededge.set_lineid(transitedge.lineid);
+
+      LOG_DEBUG("Add transit directededge - lineId = " + std::to_string(transitedge.lineid) +
+         " Route Key = " + std::to_string(transitedge.routeid) +
+         " EndStop " + endstopname);
+
+      // Add edge info to the tile and set the offset in the directed edge
+      // Leave the name empty. Use the trip Id to look up the route Id and
+      // route within TripPathBuilder.
+      bool added = false;
+      std::vector<std::string> names;
+
+      std::vector<PointLL> points;
+      std::vector<float> distance;
+      // get the indexes and vector of points for this shape id
+      const auto& found = shape_data.find(transitedge.shapeid);
+      if (transitedge.shapeid != 0 && found != shape_data.cend()) {
+        const auto& shape_d = found->second;
+        points = shape_d.shape;
+        // copy only the distances that we care about.
+        std::copy((distances.cbegin()+shape_d.begins),
+                  (distances.cbegin()+shape_d.ends),back_inserter(distance));
+      }
+      else if (transitedge.shapeid != 0)
+        LOG_WARN("Shape Id not found: " + std::to_string(transitedge.shapeid));
+
+      // TODO - if we separate transit edges based on more than just routeid
+      // we will need to do something to differentiate edges (maybe use
+      // lineid) so the shape doesn't get messed up.
+      auto shape = GetShape(stopll, endll, transitedge.shapeid, transitedge.orig_dist_traveled,
+                            transitedge.dest_dist_traveled, points, distance);
+      uint32_t edge_info_offset = tilebuilder_transit.AddEdgeInfo(transitedge.routeid,
+           origin_node, endnode, 0, shape, names, added);
+      directededge.set_edgeinfo_offset(edge_info_offset);
+      directededge.set_forward(added);
+
+      // Add to list of directed edges
+      tilebuilder_transit.directededges().emplace_back(std::move(directededge));
+      transitedges++;
+    }
+
+    // Get the directed edge count, log an error if no directed edges are added
+    uint32_t edge_count = tilebuilder_transit.directededges().size() - node.edge_index();
+    if (edge_count == 0) {
+      // Set the edge index to 0
+      node.set_edge_index(0);
+      no_dir_edge_count++;
+    }
+
+    // Add the node
+    node.set_edge_count(edge_count);
+    tilebuilder_transit.nodes().emplace_back(std::move(node));
+  }
+
+  // Log the number of added nodes and edges
+  auto t2 = std::chrono::high_resolution_clock::now();
+  uint32_t msecs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  t2 - t1).count();
+  LOG_INFO("Tile " + std::to_string(tileid)
+          + ": added " + std::to_string(transitedges) + " transit edges, and "
+          + std::to_string(tilebuilder_transit.nodes().size()) + " nodes. time = "
+          + std::to_string(msecs) + " ms");
+}
+
+// We make sure to lock on reading and writing since tiles are now being
+// written. Also lock on queue access since shared by different threads.
+void build_tiles(const boost::property_tree::ptree& pt, std::mutex& lock,
+                 const std::unordered_set<GraphId>& all_tiles,
+                 std::unordered_set<GraphId>::const_iterator tile_start,
+                 std::unordered_set<GraphId>::const_iterator tile_end,
+                 std::promise<builder_stats>& results) {
+
+  uint32_t no_dir_edge_count = 0;
+  GraphReader reader_transit_level(pt);
+  const TileHierarchy& hierarchy_transit_level = reader_transit_level.GetTileHierarchy();
+
+  // Iterate through the tiles in the queue and find any that include stops
+  for(; tile_start != tile_end; ++tile_start) {
+    // Get the next tile Id from the queue and get a tile builder
+    if(reader_transit_level.OverCommitted())
+      reader_transit_level.Clear();
+    GraphId tile_id = tile_start->Tile_Base();
+
+    // Get transit pbf tile
+    const std::string transit_dir = pt.get<std::string>("transit_dir");
+    //std::cout << transit_dir << std::endl;
+
+    std::string file_name = GraphTile::FileSuffix(GraphId(tile_id.tileid(), tile_id.level(),0), hierarchy_transit_level);
+    boost::algorithm::trim_if(file_name, boost::is_any_of(".gph"));
+    file_name += ".pbf";
+    const std::string file = transit_dir + '/' + file_name;
+
+    // Make sure it exists
+    if (!boost::filesystem::exists(file)) {
+      LOG_ERROR("File not found.  " + file);
+      return;
+    }
+
+    Transit transit = read_pbf(file, lock);
+    // Get Valhalla tile - get a read only instance for reference and
+    // a writeable instance (deserialize it so we can add to it)
+    lock.lock();
+
+    GraphId transit_tile_id = GraphId(tile_id.tileid(), tile_id.level()+1, tile_id.id());
+    const GraphTile* transit_tile = reader_transit_level.GetGraphTile(transit_tile_id);
+    GraphTileBuilder tilebuilder_transit(hierarchy_transit_level, transit_tile_id, false);
+
+    auto tz = DateTime::get_tz_db().from_index(DateTime::get_tz_db().to_index("America/New_York"));
+    uint32_t tile_creation_date = DateTime::days_from_pivot_date(DateTime::get_formatted_date(DateTime::iso_date_time(tz)));
+    tilebuilder_transit.AddTileCreationDate(tile_creation_date);
+
+    lock.unlock();
+
+    std::unordered_multimap<GraphId, GraphId> children;
+    for (uint32_t i = 0; i < transit.stops_size(); i++) {
+      const Transit_Stop& stop = transit.stops(i);
+
+      // Store stop information in TransitStops
+      tilebuilder_transit.AddTransitStop( { tilebuilder_transit.AddName(stop.onestop_id()),
+                                            tilebuilder_transit.AddName(stop.name()) } );
+
+      /** TODO - parent/child relationships
+      if (stop.type == 0 && stop.parent.Is_Valid()) {
+        children.emplace(stop.parent, stop.pbf_graphid);
+      }       **/
+    }
+
+    //Get all the shapes for this tile and calculate the distances
+    std::unordered_map<uint32_t, Shape> shapes;
+    std::vector<float> distances;
+    for (uint32_t i = 0; i < transit.shapes_size(); i++) {
+      const Transit_Shape& shape = transit.shapes(i);
+      const std::vector<PointLL> trip_shape = decode7<std::vector<PointLL> >(shape.encoded_shape());
+
+      float distance = 0.0f;
+      Shape shape_data;
+      //first is always 0.0f.
+      distances.push_back(distance);
+      shape_data.begins = distances.size()-1;
+
+      // loop through the points getting the distances.
+      for (size_t index = 0; index < trip_shape.size() - 1; ++index) {
+        PointLL p0 = trip_shape[index];
+        PointLL p1 = trip_shape[index + 1];
+        distance += p0.Distance(p1);
+        distances.push_back(distance);
+      }
+      //must be distances.size for the end index as we use std::copy later on and want
+      //to include the last element in the vector we wish to copy.
+      shape_data.ends = distances.size();
+      shape_data.shape = trip_shape;
+      //shape id --> begin and end indexes in the distance vector and vector of points.
+      shapes[shape.shape_id()] = shape_data;
+    }
+
+    LOG_INFO("Tile " + std::to_string(tile_id.tileid()) + ": added " +
+             std::to_string(transit.stops_size()) + " stops and " +
+             std::to_string(transit.shapes_size()) + " shapes");
+
+    // Get all scheduled departures from the stops within this tile.
+    std::map<GraphId, StopEdges> stop_edge_map;
+    uint32_t unique_lineid = 1;
+    std::vector<TransitDeparture> transit_departures;
+
+    // Create a map of stop key to index in the stop vector
+
+    // Process schedule stop pairs (departures)
+    std::unordered_map<GraphId, bool> stop_access;
+    std::unordered_multimap<GraphId, Departure> departures =
+                ProcessStopPairs(tilebuilder_transit,tile_creation_date,
+                                 transit, stop_access, file, tile_id, lock);
+
+    // Form departures and egress/station/platform hierarchy
+    for (uint32_t i = 0; i < transit.stops_size(); i++) {
+      const Transit_Stop& stop = transit.stops(i);
+      GraphId stop_pbf_graphid = GraphId(stop.graphid());
+      StopEdges stopedges;
+      stopedges.origin_pbf_graphid = stop_pbf_graphid;
+
+      /** TODO - Identify any parent-child edge connections
+      if (stop.type == 1) {
+        // Station - identify any children.
+        auto range = children.equal_range(stop.pbf_graphid);
+        for(auto kv = range.first; kv != range.second; ++kv)
+          stopedges.intrastation.push_back(kv->second);
+      } else if (stop.parent != 0) {
+        stopedges.intrastation.push_back(stop.parent);
+      } **/
+
+      // TODO - perhaps replace this code with use of headsign below
+      // to solve problem of a trip that doesn't go the whole way to
+      // the end of the route line
+      std::map<std::pair<uint32_t, GraphId>, uint32_t> unique_transit_edges;
+      auto range = departures.equal_range(stop_pbf_graphid);
+       for(auto key = range.first; key != range.second; ++key) {
+         Departure dep = key->second;
+
+         // Identify unique route and arrival stop pairs - associate to a
+         // unique line Id stored in the directed edge.
+         uint32_t lineid;
+         auto m = unique_transit_edges.find({dep.route, dep.dest_pbf_graphid});
+         if (m == unique_transit_edges.end()) {
+           // Add to the map and update the line id
+           lineid = unique_lineid;
+           unique_transit_edges[{dep.route, dep.dest_pbf_graphid}] = unique_lineid;
+           unique_lineid++;
+           stopedges.lines.emplace_back(TransitLine{lineid, dep.route,
+                 dep.dest_pbf_graphid, dep.shapeid, dep.orig_dist_traveled,
+                 dep.dest_dist_traveled});
+         } else {
+           lineid = m->second;
+         }
+
+        // Form transit departures
+        TransitDeparture td(lineid, dep.trip, dep.route,
+                    dep.blockid, dep.headsign_offset, dep.dep_time,
+                    dep.elapsed_time, dep.schedule_index);
+        tilebuilder_transit.AddTransitDeparture(std::move(td));
+      }
+
+      // TODO Get any transfers from this stop (no transfers currently
+      // available from Transitland)
+      // AddTransfers(tilebuilder);
+
+      // Add to stop edge map - track edges that need to be added. This is
+      // sorted by graph Id so the stop nodes are added in proper order
+      stop_edge_map.insert({stop_pbf_graphid, stopedges});
+    }
+
+    // Add routes to the tile. Get vector of route types.
+    std::vector<uint32_t> route_types = AddRoutes(transit, tilebuilder_transit);
+    LOG_INFO("Tile " + std::to_string(tile_id.tileid()) +
+             ": added " + std::to_string(route_types.size()) + " routes");
+
+    // Add nodes, directededges, and edgeinfo
+    AddToGraph(tilebuilder_transit, hierarchy_transit_level, tile_id, file, transit_dir,
+               lock, all_tiles, stop_edge_map, stop_access, shapes, distances,
+               route_types, no_dir_edge_count);
+
+    // Write the new file
+    lock.lock();
+    tilebuilder_transit.StoreTileData();
+    lock.unlock();
+  }
+
+  // Send back the statistics
+  results.set_value({no_dir_edge_count});
+}
+
+void build(const ptree& pt, const std::unordered_set<GraphId>& all_tiles,
+           unsigned int thread_count = std::max(static_cast<unsigned int>(1), std::thread::hardware_concurrency())) {
+
+  LOG_INFO("Building transit network.");
+
+  auto t1 = std::chrono::high_resolution_clock::now();
+  if (!all_tiles.size()) {
+    LOG_INFO("No transit tiles found. Transit will not be added.");
+    return;
+  }
+
+  // TODO - intermediate pass to find any connections that cross into different
+  // tile than the stop
+
+  // Second pass - for all tiles with transit stops get all transit information
+  // and populate tiles
+
+  // A place to hold worker threads and their results
+  // (Change threads to 1 if running DEBUG to get more info)
+  //std::vector<std::shared_ptr<std::thread> > threads(1);
+  std::vector<std::shared_ptr<std::thread> > threads(
+      std::max(static_cast<uint32_t>(1),
+               pt.get<uint32_t>("mjolnir.concurrency",
+                                std::thread::hardware_concurrency())));
+
+  // An atomic object we can use to do the synchronization
+  std::mutex lock;
+
+  // A place to hold the results of those threads (exceptions, stats)
+  std::list<std::promise<builder_stats> > results;
+
+  // Start the threads, divvy up the work
+  LOG_INFO("Adding " + std::to_string(all_tiles.size()) + " transit tiles to the transit graph...");
+  size_t floor = all_tiles.size() / threads.size();
+  size_t at_ceiling = all_tiles.size() - (threads.size() * floor);
+  std::unordered_set<GraphId>::const_iterator tile_start, tile_end = all_tiles.begin();
+
+  // Atomically pass around stats info
+  for (size_t i = 0; i < threads.size(); ++i) {
+    // Figure out how many this thread will work on (either ceiling or floor)
+    size_t tile_count = (i < at_ceiling ? floor + 1 : floor);
+    // Where the range begins
+    tile_start = tile_end;
+    // Where the range ends
+    std::advance(tile_end, tile_count);
+    // Make the thread
+    results.emplace_back();
+    threads[i].reset(
+        new std::thread(build_tiles, std::cref(pt.get_child("mjolnir")),
+                        std::ref(lock), std::cref(all_tiles), tile_start, tile_end,
+                        std::ref(results.back())));
+  }
+
+  // Wait for them to finish up their work
+  for (auto& thread : threads) {
+    thread->join();
+  }
+
+
+  // Check all of the outcomes, to see about maximum density (km/km2)
+  builder_stats stats{};
+  uint32_t total_no_dir_edge_count = 0;
+  for (auto& result : results) {
+    // If something bad went down this will rethrow it
+    try {
+      auto thread_stats = result.get_future().get();
+      stats(thread_stats);
+      total_no_dir_edge_count += stats.no_dir_edge_count;
+    }
+    catch(std::exception& e) {
+      //TODO: throw further up the chain?
+    }
+  }
+
+  if (total_no_dir_edge_count)
+    LOG_ERROR("There were " + std::to_string(total_no_dir_edge_count) + " nodes with no directed edges");
+
+
+  auto t2 = std::chrono::high_resolution_clock::now();
+  uint32_t secs = std::chrono::duration_cast<std::chrono::seconds>(t2 - t1).count();
+  LOG_INFO("Finished building transit network - took " + std::to_string(secs) + " secs");
+}
+
 int main(int argc, char** argv) {
   if(argc < 2) {
     std::cerr << "Usage: " << std::string(argv[0]) << " valhalla_config transit_land_url per_page [target_directory] [transit_land_api_key]" << std::endl;
@@ -854,6 +1747,10 @@ int main(int argc, char** argv) {
 
   //spawn threads to connect dangling stop pairs to adjacent tiles' stops
   stitch(pt, all_tiles, dangling_tiles);
+
+  // update tile dir loc.  Don't want to overwrite the real transit tiles
+  if(argc > 4) { pt.get_child("mjolnir").erase("tile_dir"); pt.add("mjolnir.tile_dir", std::string(argv[4])); }
+  build(pt, all_tiles);
 
   return 0;
 }

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -580,7 +580,6 @@ void build(const std::string& transit_dir,
     GraphId transit_tile_id = GraphId(tile_id.tileid(), tile_id.level()+1, tile_id.id());
     const GraphTile* transit_tile = reader_transit_level.GetGraphTile(transit_tile_id);
     GraphTileBuilder tilebuilder_transit(hierarchy_transit_level, transit_tile_id, true);
-    tilebuilder_transit.AddTileCreationDate(local_tile->header()->date_created());
 
     lock.unlock();
 

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -41,8 +41,8 @@ namespace {
 struct OSMConnectionEdge {
   GraphId osm_node;
   GraphId stop_node;
-  uint64_t wayid;
   float length;
+  uint64_t wayid;
   std::vector<std::string> names;
   std::list<PointLL> shape;
 
@@ -268,9 +268,9 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
       tilebuilder_transit.directededges().emplace_back(std::move(currentedges[idx]));
     }
 
-    // Add directed edges for any connections from the OSM node
-    // to a transit stop
-    // level 2
+    // Add directed edges for any connections from the transit stop
+    // to the osm node
+    // level 3
     bool admin_set = false;
     for (const auto& conn : connection_edges) {
       if (conn.stop_node.id() == nb.stop_index()) {
@@ -537,6 +537,10 @@ void build(const std::string& transit_dir,
     // Get the next tile Id from the queue and get a tile builder
     if(reader_local_level.OverCommitted())
       reader_local_level.Clear();
+
+    if (reader_transit_level.OverCommitted())
+      reader_transit_level.Clear();
+
     GraphId tile_id = tile_start->Tile_Base();
 
     // Get transit pbf tile

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -15,9 +15,7 @@
 #include <spatialite.h>
 #include <fstream>
 #include <iostream>
-#define BOOST_NO_CXX11_SCOPED_ENUMS
 #include <boost/filesystem/operations.hpp>
-#undef BOOST_NO_CXX11_SCOPED_ENUMS
 
 #include <boost/algorithm/string.hpp>
 #include <boost/foreach.hpp>


### PR DESCRIPTION
Moved transit stops, schedules, shape, and transit_line logic to transit_fetcher.
Transit builder now just makes the transit connections from level 2 to 3 and vice versa.  

No diffs in NYC or SF routes.  Small diffs in Rome.  Actually, better routes.
