### PR TITLE
Transit fixes

### DIFF
--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -80,7 +80,7 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode, DirectedEdge& edge,
 		uint32_t& dupcount, std::string& endnodeiso) {
 
   if (!end_tile) {
-    LOG_ERROR("End tile invalid.")
+    LOG_WARN("End tile invalid.")
     return kMaxEdgesPerNode;
   }
   // Get the tile at the end node and get the node info

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -254,8 +254,7 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
   rescount = tilebuilder_transit.header()->access_restriction_count();
 
   // Iterate through the nodes - add back any stored edges and insert any
-  // connections from a node to a transit stop. Update each nodes edge index.
-  nodeid = 0;
+  // connections from a transit stop to a node.. Update each nodes edge index.
   added_edges = 0;
   connedges = 0;
   for (auto& nb : currentnodes) {
@@ -331,7 +330,6 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
     nb.set_edge_index(edge_index);
     nb.set_edge_count(tilebuilder_transit.directededges().size() - edge_index);
     tilebuilder_transit.nodes().emplace_back(std::move(nb));
-    nodeid++;
   }
 
   // Some validation here...
@@ -614,6 +612,10 @@ void build(const std::string& transit_dir,
         children.emplace(stop.parent, stop.pbf_graphid);
       }       **/
     }
+
+    // this happens when you are running against small extracts...no work to be done.
+    if (connection_edges.size() == 0)
+      continue;
 
     // Sort the connection edges
     std::sort(connection_edges.begin(), connection_edges.end());

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -380,16 +380,26 @@ void AddOSMConnection(const Transit_Stop& stop, const GraphTile* tile,
           float start_distance = node->latlng().Distance(stop_ll);
 
           const GraphTile* endnode_tile = tile;
-          if ( directededge->endnode().Tile_Base() != tile->id()) {
+          if ( directededge->endnode().Tile_Base() != endnode_tile->id()) {
               // Get the end node tile
               lock.lock();
               endnode_tile = reader.GetGraphTile(directededge->endnode());
               lock.unlock();
           }
 
-          const DirectedEdge* opp_de = endnode_tile->directededge(node->edge_index() + directededge->opp_index());
+          GraphId id = directededge->endnode();
+          const DirectedEdge* opp_de = endnode_tile->directededge(endnode_tile->node(id)->edge_index() +
+                                                                  directededge->opp_index());
           GraphId end_node = opp_de->endnode();
           float end_distance = 0.0f;
+
+          //it is possible that the opp DE endnode could be in another tile.
+          if ( end_node.Tile_Base() != endnode_tile->id()) {
+            // Get the end node tile
+            lock.lock();
+            endnode_tile = reader.GetGraphTile(end_node);
+            lock.unlock();
+          }
 
           const NodeInfo* closest_node = endnode_tile->node(end_node.id());
           end_distance = closest_node->latlng().Distance(stop_ll);


### PR DESCRIPTION
Fixed 2 core dumps. 

transitbuilder.  
Don't use node index to get opp DE, but use the endnode from the directed_edge. It is possible that the opp DE endnode could be in another tile. Getting the correct tile now.