### PR TITLE
dont mix sizes to allow building on 32bit machines

### DIFF
--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -290,7 +290,7 @@ void get_stops(Transit& tile, std::unordered_map<std::string, uint64_t>& stops,
   }
 }
 
-void get_routes(Transit& tile, std::unordered_map<std::string, uint64_t>& routes,
+void get_routes(Transit& tile, std::unordered_map<std::string, size_t>& routes,
     const std::unordered_map<std::string, std::string>& websites,
     const std::unordered_map<std::string, std::string>& short_names, const ptree& response) {
   for(const auto& route_pt : response.get_child("routes")) {
@@ -347,7 +347,7 @@ void get_routes(Transit& tile, std::unordered_map<std::string, uint64_t>& routes
   }
 }
 
-void get_stop_patterns(Transit& tile, std::unordered_map<std::string, uint64_t>& shapes, const ptree& response) {
+void get_stop_patterns(Transit& tile, std::unordered_map<std::string, size_t>& shapes, const ptree& response) {
   for(const auto& shape_pt : response.get_child("route_stop_patterns")) {
     auto* shape = tile.add_shapes();
     auto shape_id = shape_pt.second.get<std::string>("onestop_id");


### PR DESCRIPTION
32bit machines fail builds when you assume that size_t is 64bits wide. another reason to not specify the number of bits you need unless you must to ensure wire compatibility, reduce memory, etc