### PR TITLE
Fix to not generate shortcuts that might drop certain maneuvers.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -167,7 +167,7 @@ valhalla_build_speeds_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) @BOOST_LDFLAGS@
 
 valhalla_build_statistics_SOURCES = src/mjolnir/valhalla_build_statistics.cc
 valhalla_build_statistics_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS) @BOOST_CPPFLAGS@
-valhalla_build_statistics_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) @BOOST_LDFLAGS@ $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB) @PROTOC_LIBS@ -lsqlite3 libvalhalla_mjolnir.la
+valhalla_build_statistics_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) @BOOST_LDFLAGS@ $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB) @PROTOC_LIBS@ -lz libvalhalla_mjolnir.la
 
 # tests
 check_PROGRAMS = \

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -18,6 +18,7 @@
 #include <future>
 #include <mutex>
 #include <numeric>
+#include <tuple>
 
 #include <valhalla/midgard/logging.h>
 #include <valhalla/midgard/pointll.h>
@@ -245,235 +246,21 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode, DirectedEdge& edge,
   return opp_index;
 }
 
-bool IsPedestrianTerminal(GraphTileBuilder &tilebuilder, GraphReader& reader, std::mutex& lock,
-                const GraphId& startnode,
-                NodeInfo& startnodeinfo,
-                DirectedEdge& directededge,
-                validator_stats::RouletteData& rd,
-                const uint32_t idx) {
-
-  bool is_terminal = true;
-  lock.lock();
-  const GraphTile* tile = reader.GetGraphTile(startnode);
-  lock.unlock();
-  const DirectedEdge* diredge = tile->directededge(startnodeinfo.edge_index());
-  for (uint32_t i = 0; i < startnodeinfo.edge_count(); i++, diredge++) {
-
-    if (i == idx)
-      continue;
-
-    if (((diredge->reverseaccess() & kPedestrianAccess) ||
-        (diredge->forwardaccess() & kPedestrianAccess)) &&
-        (!(diredge->forwardaccess() & kAutoAccess) &&
-          !(diredge->reverseaccess() & kAutoAccess))){
-      continue;
-    }
-    else {
-      is_terminal = false;
-      break;
-    }
-  }
-
-  if (is_terminal) {
-    if (startnodeinfo.edge_count() > 1) {
-      rd.AddTask(startnodeinfo.latlng(),
-                 tilebuilder.edgeinfo(directededge.edgeinfo_offset())->wayid(),
-                 tilebuilder.edgeinfo(directededge.edgeinfo_offset())->shape());      
-      return true;
-    }
-  }
-  return false;
-}
-
-bool IsLoopTerminal(GraphTileBuilder &tilebuilder, GraphReader& reader, std::mutex& lock,
-                const GraphId& startnode,
-                NodeInfo& startnodeinfo,
-                DirectedEdge& directededge,
-                validator_stats::RouletteData& rd) {
-
-  lock.lock();
-  const GraphTile* tile = reader.GetGraphTile(startnode);
-  lock.unlock();
-  const DirectedEdge* diredge = tile->directededge(startnodeinfo.edge_index());
-  uint32_t inbound = 0, outbound = 0;
-
-  for (uint32_t i = 0; i < startnodeinfo.edge_count(); i++, diredge++) {
-
-    if (((diredge->forwardaccess() & kAutoAccess) &&
-        !(diredge->reverseaccess() & kAutoAccess)) ||
-        ((diredge->forwardaccess() & kAutoAccess) &&
-         (diredge->reverseaccess() & kAutoAccess)))
-      outbound++;
-
-    if ((!(diredge->forwardaccess() & kAutoAccess) &&
-        (diredge->reverseaccess() & kAutoAccess)) ||
-        ((diredge->forwardaccess() & kAutoAccess) &&
-         (diredge->reverseaccess() & kAutoAccess)))
-      inbound++;
-  }
-
-  if ((outbound >= 2 && inbound == 0) || (inbound >= 2 && outbound == 0)) {
-    rd.AddTask(startnodeinfo.latlng(),
-               tilebuilder.edgeinfo(directededge.edgeinfo_offset())->wayid(),
-               tilebuilder.edgeinfo(directededge.edgeinfo_offset())->shape());
-    return true;
-  }
-  return false;
-}
-
-bool IsReversedOneway(GraphTileBuilder &tilebuilder, GraphReader& reader, std::mutex& lock,
-                const GraphId& startnode,
-                NodeInfo& startnodeinfo,
-                DirectedEdge& directededge,
-                validator_stats::RouletteData& rd) {
-
-  lock.lock();
-  const GraphTile* tile = reader.GetGraphTile(startnode);
-  lock.unlock();
-  const DirectedEdge* diredge = tile->directededge(startnodeinfo.edge_index());
-  uint32_t inbound = 0, outbound = 0;
-
-  for (uint32_t i = 0; i < startnodeinfo.edge_count(); i++, diredge++) {
-
-    if ((diredge->forwardaccess() & kAutoAccess) &&
-        !(diredge->reverseaccess() & kAutoAccess))
-      outbound++;
-
-    if (!(diredge->forwardaccess() & kAutoAccess) &&
-        (diredge->reverseaccess() & kAutoAccess))
-      inbound++;
-  }
-
-  if (!outbound && inbound)
-  {
-    const GraphId endnode = directededge.endnode();
-    lock.lock();
-    const GraphTile* tile = reader.GetGraphTile(endnode);
-    lock.unlock();
-    const NodeInfo* nodeinfo = tile->node(endnode.id());
-
-    const DirectedEdge* diredge = tile->directededge(nodeinfo->edge_index());
-    uint32_t inbound = 0, outbound = 0;
-
-    for (uint32_t i = 0; i < nodeinfo->edge_count(); i++, diredge++) {
-
-      if ((diredge->forwardaccess() & kAutoAccess) &&
-          !(diredge->reverseaccess() & kAutoAccess))
-        outbound++;
-
-      if (!(diredge->forwardaccess() & kAutoAccess) &&
-          (diredge->reverseaccess() & kAutoAccess))
-        inbound++;
-    }
-
-    if (!outbound && inbound) {
-      rd.AddTask(startnodeinfo.latlng(),
-                 tilebuilder.edgeinfo(directededge.edgeinfo_offset())->wayid(),
-                 tilebuilder.edgeinfo(directededge.edgeinfo_offset())->shape());
-      return true;
-    }
-  }
-
-  return false;
-}
-
-void AddStatistics(validator_stats& stats, DirectedEdge& directededge,
-                   const uint32_t tileid, std::string& begin_node_iso,
-                   HGVRestrictionTypes& hgv, GraphTileBuilder& tilebuilder,
-                   GraphReader& graph_reader, std::mutex& lock, GraphId& node, NodeInfo& nodeinfo, uint32_t idx) {
-  auto rclass = directededge.classification();
-  float edge_length = (tileid == directededge.endnode().tileid()) ?
-        directededge.length() * 0.5f : directededge.length() * 0.25f;
-
-  // Add truck stats.
-  if (directededge.truck_route()) {
-    stats.add_tile_truck_route(tileid, rclass, edge_length);
-    stats.add_country_truck_route(begin_node_iso, rclass, edge_length);
-  }
-  if (hgv.hazmat) {
-    stats.add_tile_hazmat(tileid, rclass, edge_length);
-    stats.add_country_hazmat(begin_node_iso, rclass, edge_length);
-  }
-  if (hgv.axle_load) {
-    stats.add_tile_axle_load(tileid, rclass);
-    stats.add_country_axle_load(begin_node_iso, rclass);
-  }
-  if (hgv.height) {
-    stats.add_tile_height(tileid, rclass);
-    stats.add_country_height(begin_node_iso, rclass);
-  }
-  if (hgv.length) {
-    stats.add_tile_length(tileid, rclass);
-    stats.add_country_length(begin_node_iso, rclass);
-  }
-  if (hgv.weight) {
-    stats.add_tile_weight(tileid, rclass);
-    stats.add_country_weight(begin_node_iso, rclass);
-  }
-  if (hgv.width) {
-    stats.add_tile_width(tileid, rclass);
-    stats.add_country_width(begin_node_iso, rclass);
-  }
-
-  // Add all other statistics
-  // Only consider edge if edge is good and it's not a link
-  if (!directededge.link()) {
-    //Determine access for directed edge
-    auto fward = ((kAutoAccess & directededge.forwardaccess()) == kAutoAccess);
-    auto bward = ((kAutoAccess & directededge.reverseaccess()) == kAutoAccess);
-    // Check if one way
-    if ((!fward || !bward) && (fward || bward)) {
-      edge_length *= 0.5f;
-      const GraphTile* tile = graph_reader.GetGraphTile(node);
-      bool found = IsPedestrianTerminal(tilebuilder,graph_reader,lock,node,nodeinfo,directededge,stats.roulette_data,idx);
-      if (!found && directededge.endnode().id() == node.id()) {
-        lock.lock();
-        const GraphTile* end_tile = graph_reader.GetGraphTile(directededge.endnode());
-        lock.unlock();
-        if (tile->id() == end_tile->id())
-          found = IsLoopTerminal(tilebuilder,graph_reader,lock,node,nodeinfo,directededge,stats.roulette_data);
-      }
-      if (!found && directededge.endnode().id() != node.id()) {
-        found = IsReversedOneway(tilebuilder,graph_reader,lock,node,nodeinfo,directededge,stats.roulette_data);
-      }
-      stats.add_tile_one_way(tileid, rclass, edge_length);
-      stats.add_country_one_way(begin_node_iso, rclass, edge_length);
-    }
-    // Check if this edge is internal
-    if (directededge.internal()) {
-      stats.add_tile_int_edge(tileid, rclass);
-      stats.add_country_int_edge(begin_node_iso, rclass);
-    }
-    // Check if edge has maxspeed tag
-    if (directededge.speed_type() == SpeedType::kTagged){
-      stats.add_tile_speed_info(tileid, rclass, edge_length);
-      stats.add_country_speed_info(begin_node_iso, rclass, edge_length);
-    }
-    // Check if edge has any names
-    if (tilebuilder.edgeinfo(directededge.edgeinfo_offset())->name_count() > 0) {
-      stats.add_tile_named(tileid, rclass, edge_length);
-      stats.add_country_named(begin_node_iso, rclass, edge_length);
-    }
-
-    // Add road lengths to statistics for current country and tile
-    stats.add_country_road(begin_node_iso, rclass, edge_length);
-    stats.add_tile_road(tileid, rclass, edge_length);
-  }
-}
-
 using tweeners_t = GraphTileBuilder::tweeners_t;
 void validate(const boost::property_tree::ptree& pt,
               std::deque<GraphId>& tilequeue, std::mutex& lock,
-              std::promise<std::pair<validator_stats, tweeners_t>>& result) {
-
-    // Our local class for gathering the stats
-    validator_stats stats;
+              std::promise<std::tuple<std::vector<uint32_t>, std::vector<std::vector<float>>, tweeners_t>>& result) {
     // Our local copy of edges binned to tiles that they pass through (dont start or end in)
     tweeners_t tweeners;
     // Local Graphreader
     GraphReader graph_reader(pt.get_child("mjolnir"));
     // Get some things we need throughout
     const auto& hierarchy = graph_reader.GetTileHierarchy();
+    auto numLevels = hierarchy.levels().size();
+    // vector to hold densities for each level
+    std::vector<std::vector<float>> densities(numLevels);
+    // Array to hold duplicates
+    std::vector<uint32_t> duplicates (numLevels, 0);
 
     // Check for more tiles
     while (true) {
@@ -532,14 +319,10 @@ void validate(const boost::property_tree::ptree& pt,
             }
           }
 
-          // HGV restriction mask (for stats)
-          HGVRestrictionTypes hgv = {};
-
           // Validate access restrictions. TODO - should check modes as well
           uint32_t ar_modes = de->access_restriction();
           if (ar_modes) {
             //since only truck restrictions exist, we can still get all restrictions
-            //later we may only want to get just the truck ones for stats.
             auto res = tile->GetAccessRestrictions(idx, kAllAccess);
             if (res.size() == 0) {
               LOG_ERROR("Directed edge marked as having access restriction but none found ; tile level = " +
@@ -548,29 +331,6 @@ void validate(const boost::property_tree::ptree& pt,
               for (auto r : res) {
                 if (r.edgeindex() != idx) {
                   LOG_ERROR("Access restriction edge index does not match idx");
-                } else {// log stats.  currently only for truck right now
-                  switch (r.type()) {
-                    case AccessType::kHazmat:
-                      hgv.hazmat = true;
-                      break;
-                    case AccessType::kMaxAxleLoad:
-                      hgv.axle_load = true;
-                      break;
-                    case AccessType::kMaxHeight:
-                      hgv.height = true;
-                      break;
-                    case AccessType::kMaxLength:
-                      hgv.length = true;
-                      break;
-                    case AccessType::kMaxWeight:
-                      hgv.weight = true;
-                      break;
-                    case AccessType::kMaxWidth:
-                      hgv.width = true;
-                      break;
-                    default:
-                      break;
-                  }
                 }
               }
             }
@@ -622,12 +382,6 @@ void validate(const boost::property_tree::ptree& pt,
 
           // Add the directed edge to the local list
           directededges.emplace_back(std::move(directededge));
-
-          // Statistics
-          if (valid_length) {
-            AddStatistics(stats, directededge, tileid, begin_node_iso,
-                          hgv, tilebuilder, graph_reader, lock, node, nodeinfo, j);
-          }
         }
 
         // Add the node to the list
@@ -640,9 +394,7 @@ void validate(const boost::property_tree::ptree& pt,
                    ((bb.maxx() - bb.minx()) *
                        DistanceApproximator::MetersPerLngDegree(bb.Center().y()) * kKmPerMeter);
       float density = (roadlength * 0.0005f) / area;
-      stats.add_density(density, level);
-      stats.add_tile_area(tileid, area);
-      stats.add_tile_geom(tileid, tiles.TileBounds(tileid));
+      densities[level].push_back(density);
 
       // Set the relative road density within this tile.
       uint32_t relative_density;
@@ -676,11 +428,11 @@ void validate(const boost::property_tree::ptree& pt,
       lock.unlock();
 
       // Add possible duplicates to return class
-      stats.add_dup(dupcount, level);
+      duplicates[level] = dupcount;
     }
 
-    // Fill promise with statistics
-    result.set_value(std::make_pair(std::move(stats), std::move(tweeners)));
+    // Fill promise with return data
+    result.set_value(std::make_tuple(std::move(duplicates), std::move(densities), std::move(tweeners)));
   }
 
   //take tweeners from different tiles' perspectives and merge into a single tweener
@@ -740,7 +492,8 @@ namespace mjolnir {
     // Graphreader
     TileHierarchy hierarchy(pt.get<std::string>("mjolnir.tile_dir"));
     // Make sure there are at least 2 levels!
-    if (hierarchy.levels().size() < 2)
+    auto numHierarchyLevels = hierarchy.levels().size();
+    if (numHierarchyLevels < 2)
       throw std::runtime_error("Bad tile hierarchy - need 2 levels");
 
     // Create a randomized queue of tiles to work from
@@ -781,7 +534,7 @@ namespace mjolnir {
                  pt.get<unsigned int>("concurrency",std::thread::hardware_concurrency())));
 
     // Setup promises
-    std::list<std::promise<std::pair<validator_stats, tweeners_t> > > results;
+    std::list<std::promise<std::tuple<std::vector<uint32_t>, std::vector<std::vector<float>>, tweeners_t> > > results;
 
     // Spawn the threads
     for (auto& thread : threads) {
@@ -794,14 +547,19 @@ namespace mjolnir {
     for (auto& thread : threads)
       thread->join();
     // Get the promise from the future
-    validator_stats stats;
+    std::vector<uint32_t> duplicates(numHierarchyLevels, 0);
+    std::vector<std::vector<float>> densities(3);
     tweeners_t tweeners;
     for (auto& result : results) {
-      auto pair = result.get_future().get();
-      //keep track of stats
-      stats.add(pair.first);
+      auto data = result.get_future().get();
+      // Total up duplicates for each level
+      for (uint8_t i = 0; i < numHierarchyLevels; ++i) {
+        duplicates[i] += std::get<0>(data)[i];
+        for (auto& d : std::get<1>(data)[i])
+          densities[i].push_back(d);
+      }
       //keep track of tweeners
-      merge(pair.second, tweeners);
+      merge(std::get<2>(data), tweeners);
     }
     LOG_INFO("Finished");
 
@@ -815,28 +573,24 @@ namespace mjolnir {
       thread->join();
     LOG_INFO("Finished");
 
-    // Add up total dupcount_ and find densities
-    for (uint8_t level = 0; level <= 2; level++) {
+    // print dupcount and find densities
+    for (uint8_t level = 0; level < numHierarchyLevels; level++) {
       // Print duplicates info for level
-      std::vector<uint32_t> dups = stats.get_dups(level);
-      uint32_t dupcount = std::accumulate(dups.begin(), dups.end(), 0);
       LOG_WARN((boost::format("Possible duplicates at level: %1% = %2%")
-      % std::to_string(level) % dupcount).str());
+        % std::to_string(level) % duplicates[level]).str());
       // Get the average density and the max density
       float max_density = 0.0f;
       float sum = 0.0f;
-      for (auto density : stats.get_densities(level)) {
+      for (auto& density : densities[level]) {
         if (density > max_density) {
           max_density = density;
         }
         sum += density;
       }
-      float average_density = sum / stats.get_densities(level).size();
+      float average_density = sum / densities[level].size();
       LOG_DEBUG("Average density = " + std::to_string(average_density) +
                " max = " + std::to_string(max_density));
     }
-    stats.build_db(pt);
-    stats.roulette_data.GenerateTasks();
   }
 }
 }

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -276,6 +276,26 @@ bool CanContract(const GraphTile* tile, const NodeInfo* nodeinfo,
       e1_iso != iso || e2_iso != iso)
     return false;
 
+  // Simple check for a possible maneuver where the continuation is a turn
+  // and there are other edges at the node (forward intersecting edge or a
+  // 'T' intersection
+  if (nodeinfo->local_edge_count() > 2) {
+    // Find number of driveable edges
+    uint32_t driveable = 0;
+    for (uint32_t i = 0; i < nodeinfo->local_edge_count(); i++) {
+      if (nodeinfo->local_driveability(i) != Traversability::kNone) {
+        driveable++;
+      }
+    }
+    if (driveable > 2) {
+      uint32_t heading1 = (nodeinfo->heading(edge1->localedgeidx()) + 180) % 360;
+      uint32_t turn_degree = GetTurnDegree(heading1, nodeinfo->heading(edge2->localedgeidx()));
+      if (turn_degree > 60 && turn_degree < 300) {
+        return false;
+      }
+    }
+  }
+
   // Store the pairs of base edges entering and exiting this node
   EdgePairs edgepairs;
   edgepairs.edge1 = std::make_pair(oppedge1, edges[match.second]);

--- a/src/mjolnir/statistics_json.cc
+++ b/src/mjolnir/statistics_json.cc
@@ -1,0 +1,291 @@
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <boost/format.hpp>
+#include <sqlite3.h>
+
+#include <valhalla/baldr/json.h>
+
+using dataPair = std::pair<std::vector<std::string>*, std::unordered_map<std::string, std::vector<float>>*>;
+
+/*
+ * Handle errors returned from the db
+ * Params
+ *  rc - response code from previous sqlite3_exec call
+ *  errMsg - char* passed into the previous sqlite3_exec call
+ * Post
+ *  returns normally if there is not error
+ *  prints the db error and exits if an error occurred
+ */
+void checkDBResponse(int rc, char* errMsg) {
+  if ( rc != SQLITE_OK ) {
+    std::cout << "SQL error: " << errMsg << std::endl;
+    sqlite3_free(errMsg);
+    exit(0);
+  }
+}
+
+/*
+ * Callback function that gets the column names from the database
+ */
+static int classCallback (void *data, int argc, char **argv, char **colName) {
+  std::vector<std::string> *cat = (std::vector<std::string>*) data;
+  for (int i = 1; i < argc; ++i) {
+    cat->push_back(colName[i]);
+  }
+  cat->push_back("total");
+  return 0;
+}
+
+/*
+ * Queries the database to get road class types
+ * Params
+ *  *db - sqlite3 database connection object
+ *  classes - a vector of strings representing the road types
+ *
+ * Post
+ *  The array containing the road classes is filled
+ */
+void fillClasses(sqlite3 *db, std::vector<std::string>& classes) {
+ 
+  std::string sql = "SELECT * FROM countrydata LIMIT 1";
+  char *errMsg = 0;
+  int rc = sqlite3_exec(db, sql.c_str(), classCallback, (void*) &classes, &errMsg);
+  checkDBResponse(rc, errMsg);
+}
+
+/*
+ * Callback function to reveive query results from sqlite3_exec
+ * Params
+ *  *dataPair - the pointer used to pass data structures into this function
+ *  argc - # arguments
+ *  **argv - char array of arguments
+ *  **colName - char array returned column names from the database
+ */
+static int countryDataCallback (void *data_pair, int argc, char **argv, char **colName) {
+  dataPair* p = (dataPair*) data_pair;
+  auto* countries = std::get<0>(*p);
+  auto* data = std::get<1>(*p);
+
+  countries->push_back(argv[0]);
+  std::string line = "";
+  for (int i = 1; i < argc; ++i) {
+    line += argv[i];
+    line += " ";
+  }
+
+  std::istringstream iss(line);
+  float tok = 0;
+  float sum = 0;
+  std::vector<float> *classData = new std::vector<float>();
+
+  while (iss >> tok) {
+    classData->push_back(tok);
+    sum += tok;
+  }
+  classData->push_back(sum);
+  data->emplace(argv[0], *classData);
+
+  return 0;
+}
+
+/*
+ * Queries the database to get length of roads in each class per country
+ * Params
+ *  *db - sqlite3 database connection object
+ *  countries - vector of country iso codes
+ *  data - 2D vector of road lengths
+ *    each column belongs to a certain country
+ *    each row is a type of road
+ * Post
+ *  countries contains the iso codes of all countries in the database
+ *  data contains the lengths of each type of road for each country
+ */
+void fillCountryData(sqlite3 *db, std::vector<std::string>& countries, std::unordered_map<std::string, std::vector<float>>& data) {
+ 
+  std::string sql = "SELECT * FROM countrydata WHERE isocode IS NOT \"\"";
+
+  char *errMsg = 0;
+  dataPair data_pair = {&countries, &data};
+  int rc = sqlite3_exec(db, sql.c_str(), countryDataCallback, (void*) &data_pair, &errMsg);
+  checkDBResponse(rc, errMsg);
+}
+
+/* 
+ * Callback function to receive query results from sqlite3_exec
+ * Params
+ *  *dataPair - the pointer used to pass data structures into this function
+ *  argc - # arguments
+ *  **argv - char array of arguments
+ *  **colName - char array returned column names from the database
+ */
+static int maxSpeedCallback (void *data, int argc, char **argv, char **colName) {
+  auto* maxSpeedInfo =
+    (std::unordered_map<std::string, std::vector<float>>*) data;
+  
+  std::istringstream ss(argv[2]);
+  float val;
+  ss >> val;
+
+  maxSpeedInfo->at(argv[0]).push_back(val);
+
+  return 0;
+}
+
+/*
+ * Retrieves the maxspeed data from the database and fills the data structure
+ */
+void fillMaxSpeedData(sqlite3* db, std::unordered_map<std::string, std::vector<float>>& maxSpeedInfo) {
+ 
+  std::string sql = "SELECT isocode,type,maxspeed";
+  sql += " FROM rclassctrydata";
+  sql += " WHERE (type='Motorway' OR type='Primary' OR type='Secondary' OR type='Trunk')";
+  sql += " AND isocode IS NOT \"\"";
+
+  char *errMsg = 0;
+  int rc = sqlite3_exec(db, sql.c_str(), maxSpeedCallback, (void*) &maxSpeedInfo, &errMsg);
+  checkDBResponse(rc, errMsg);
+}
+
+/* 
+ * Callback function to receive query results from sqlite3_exec
+ * Params
+ *  *data - the pointer used to pass data structures into this function
+ *  argc - # arguments
+ *  **argv - char array of arguments
+ *  **colName - char array returned column names from the database
+ */
+static int namedCallback (void *data, int argc, char **argv, char **colName) {
+  auto* namedInfo =
+    (std::unordered_map<std::string, std::vector<float>>*) data;
+  
+  std::istringstream ss(argv[2]);
+  float val;
+  ss >> val;
+
+  namedInfo->at(argv[0]).push_back(val);
+
+  return 0;
+}
+
+/*
+ * Retrieves the named road data from the database and fills the data structure
+ */
+void fillNamedData(sqlite3* db, std::unordered_map<std::string, std::vector<float>>& namedInfo) {
+ 
+  std::string sql = "SELECT isocode,type,named";
+  sql += " FROM rclassctrydata";
+  sql += " WHERE (type='Residential' OR type='Unclassified')";
+  sql += " AND isocode IS NOT \"\"";
+
+  char *errMsg = 0;
+  int rc = sqlite3_exec(db, sql.c_str(), namedCallback, (void*) &namedInfo, &errMsg);
+  checkDBResponse(rc, errMsg);
+}
+/*
+ * Generates a javascript file that has a function to return
+ *  all the data queried from the database
+ * Params
+ *  countries - names of all the countries from the database
+ *  data - float values for all the lengths of road per country
+ *  classes - the types of road classes
+ *  maxClasses - types of road data which have corresponding maxspeed data
+ *  maxSpeedInfo - float values for each maxClass for each country
+ */
+void generateJson (std::vector<std::string>& countries,
+                   std::unordered_map<std::string, std::vector<float>>& data,
+                   std::vector<std::string>& classes,
+                   std::unordered_map<std::string, std::vector<float>>& maxSpeedInfo,
+                   std::vector<std::string>& maxClasses,
+                   std::unordered_map<std::string, std::vector<float>>& namedInfo,
+                   std::vector<std::string>& namedClasses) {
+
+  using namespace valhalla::baldr;
+
+  std::ofstream out ("road_data.json");
+  json::MapPtr map = json::map({});
+  for (size_t i = 0; i < countries.size(); ++i) {
+    map->emplace(
+      countries[i], json::map
+      ({
+        {"iso2", countries[i]},
+        {"classinfo", json::map
+        ({
+         {classes[0], json::fp_t{data[countries[i]][0]}},
+         {classes[1], json::fp_t{data[countries[i]][1]}},
+         {classes[2], json::fp_t{data[countries[i]][2]}},
+         {classes[3], json::fp_t{data[countries[i]][3]}},
+         {classes[4], json::fp_t{data[countries[i]][4]}},
+         {classes[5], json::fp_t{data[countries[i]][5]}},
+         {classes[6], json::fp_t{data[countries[i]][6]}},
+         {classes[7], json::fp_t{data[countries[i]][7]}},
+         {classes[8], json::fp_t{data[countries[i]][8]}}
+        })},
+        {"maxspeed", json::map
+        ({
+         {maxClasses[0], json::fp_t{maxSpeedInfo[countries[i]][0]}},
+         {maxClasses[1], json::fp_t{maxSpeedInfo[countries[i]][1]}},
+         {maxClasses[2], json::fp_t{maxSpeedInfo[countries[i]][2]}},
+         {maxClasses[3], json::fp_t{maxSpeedInfo[countries[i]][3]}}
+        })},
+        {"named", json::map
+        ({
+         {namedClasses[0], json::fp_t{namedInfo[countries[i]][0]}},
+         {namedClasses[1], json::fp_t{namedInfo[countries[i]][1]}},
+        })}
+      })
+    );
+  }
+  out << *map << std::endl;
+
+  out.close();
+}
+
+int main (int argc, char** argv) {
+  // If there is no input file print and error and exit
+  if (argc < 2) {
+    std::cout << "ERROR: No input file specified." << std::endl;
+    std::cout << "Usage: " << argv[0] << " statistics.sqlite" << std::endl;
+    exit(0);
+  }
+
+  // data structures
+  std::vector<std::string> roadClasses;
+  std::vector<std::string> countries;
+  std::unordered_map<std::string, std::vector<float>> roadClassInfo;
+  // speed info
+  std::vector<std::string> maxClasses = {"Motorway", "Primary", "Secondary", "Trunk"};
+  std::unordered_map<std::string, std::vector<float>> maxSpeedInfo;
+  // name info
+  std::vector<std::string> namedClasses = {"Residential", "Unclassified"};
+  std::unordered_map<std::string, std::vector<float>> namedInfo;
+
+  // open DB file
+  sqlite3 *db;
+  int rc = sqlite3_open(argv[1], &db);
+  if ( rc ) {
+    std::cout << "Opening DB failed: " << sqlite3_errmsg(db);
+    exit(0);
+  }
+
+  // fill data structures
+  fillClasses(db, roadClasses);
+  fillCountryData(db, countries, roadClassInfo);
+  // create the entries in the map
+  for (auto& s : countries) {
+    maxSpeedInfo[s];
+    namedInfo[s];
+  }
+  fillMaxSpeedData(db, maxSpeedInfo);
+  fillNamedData(db, namedInfo);
+ 
+  generateJson(countries, roadClassInfo, roadClasses,
+               maxSpeedInfo, maxClasses,
+               namedInfo, namedClasses);
+ 
+  sqlite3_close(db);
+  return 0;
+}

--- a/src/mjolnir/valhalla_build_statistics.cc
+++ b/src/mjolnir/valhalla_build_statistics.cc
@@ -1,291 +1,535 @@
+
+#include "mjolnir/graphtilebuilder.h"
+#include "mjolnir/statistics.h"
+
+#include <ostream>
+#include <boost/format.hpp>
+#include <boost/program_options.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <sstream>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <unordered_map>
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <boost/format.hpp>
-#include <sqlite3.h>
+#include <utility>
+#include <queue>
+#include <list>
+#include <thread>
+#include <future>
+#include <mutex>
 
-#include <valhalla/baldr/json.h>
+#include <valhalla/midgard/logging.h>
+#include <valhalla/midgard/pointll.h>
+#include <valhalla/midgard/distanceapproximator.h>
+#include <valhalla/baldr/tilehierarchy.h>
+#include <valhalla/baldr/graphid.h>
+#include <valhalla/baldr/graphconstants.h>
+#include <valhalla/baldr/graphreader.h>
+#include <valhalla/baldr/nodeinfo.h>
 
-using dataPair = std::pair<std::vector<std::string>*, std::unordered_map<std::string, std::vector<float>>*>;
+using namespace valhalla::midgard;
+using namespace valhalla::baldr;
+using namespace valhalla::mjolnir;
 
-/*
- * Handle errors returned from the db
- * Params
- *  rc - response code from previous sqlite3_exec call
- *  errMsg - char* passed into the previous sqlite3_exec call
- * Post
- *  returns normally if there is not error
- *  prints the db error and exits if an error occurred
- */
-void checkDBResponse(int rc, char* errMsg) {
-  if ( rc != SQLITE_OK ) {
-    std::cout << "SQL error: " << errMsg << std::endl;
-    sqlite3_free(errMsg);
-    exit(0);
+namespace bpo = boost::program_options;
+boost::filesystem::path config_file_path;
+
+namespace {
+
+struct HGVRestrictionTypes {
+  bool hazmat;
+  bool axle_load;
+  bool height;
+  bool length;
+  bool weight;
+  bool width;
+};
+
+bool IsPedestrianTerminal(GraphTileBuilder &tilebuilder, GraphReader& reader, std::mutex& lock,
+                const GraphId& startnode,
+                NodeInfo& startnodeinfo,
+                DirectedEdge& directededge,
+                validator_stats::RouletteData& rd,
+                const uint32_t idx) {
+
+  bool is_terminal = true;
+  lock.lock();
+  const GraphTile* tile = reader.GetGraphTile(startnode);
+  lock.unlock();
+  const DirectedEdge* diredge = tile->directededge(startnodeinfo.edge_index());
+  for (uint32_t i = 0; i < startnodeinfo.edge_count(); i++, diredge++) {
+
+    if (i == idx)
+      continue;
+
+    if (((diredge->reverseaccess() & kPedestrianAccess) ||
+        (diredge->forwardaccess() & kPedestrianAccess)) &&
+        (!(diredge->forwardaccess() & kAutoAccess) &&
+          !(diredge->reverseaccess() & kAutoAccess))){
+      continue;
+    }
+    else {
+      is_terminal = false;
+      break;
+    }
+  }
+
+  if (is_terminal) {
+    if (startnodeinfo.edge_count() > 1) {
+      rd.AddTask(startnodeinfo.latlng(),
+                 tilebuilder.edgeinfo(directededge.edgeinfo_offset())->wayid(),
+                 tilebuilder.edgeinfo(directededge.edgeinfo_offset())->shape());
+      return true;
+    }
+  }
+  return false;
+}
+
+bool IsLoopTerminal(GraphTileBuilder &tilebuilder, GraphReader& reader, std::mutex& lock,
+                const GraphId& startnode,
+                NodeInfo& startnodeinfo,
+                DirectedEdge& directededge,
+                validator_stats::RouletteData& rd) {
+
+  lock.lock();
+  const GraphTile* tile = reader.GetGraphTile(startnode);
+  lock.unlock();
+  const DirectedEdge* diredge = tile->directededge(startnodeinfo.edge_index());
+  uint32_t inbound = 0, outbound = 0;
+
+  for (uint32_t i = 0; i < startnodeinfo.edge_count(); i++, diredge++) {
+
+    if (((diredge->forwardaccess() & kAutoAccess) &&
+        !(diredge->reverseaccess() & kAutoAccess)) ||
+        ((diredge->forwardaccess() & kAutoAccess) &&
+         (diredge->reverseaccess() & kAutoAccess)))
+      outbound++;
+
+    if ((!(diredge->forwardaccess() & kAutoAccess) &&
+        (diredge->reverseaccess() & kAutoAccess)) ||
+        ((diredge->forwardaccess() & kAutoAccess) &&
+         (diredge->reverseaccess() & kAutoAccess)))
+      inbound++;
+  }
+
+  if ((outbound >= 2 && inbound == 0) || (inbound >= 2 && outbound == 0)) {
+    rd.AddTask(startnodeinfo.latlng(),
+               tilebuilder.edgeinfo(directededge.edgeinfo_offset())->wayid(),
+               tilebuilder.edgeinfo(directededge.edgeinfo_offset())->shape());
+    return true;
+  }
+  return false;
+}
+
+bool IsReversedOneway(GraphTileBuilder &tilebuilder, GraphReader& reader, std::mutex& lock,
+                const GraphId& startnode,
+                NodeInfo& startnodeinfo,
+                DirectedEdge& directededge,
+                validator_stats::RouletteData& rd) {
+
+  lock.lock();
+  const GraphTile* tile = reader.GetGraphTile(startnode);
+  lock.unlock();
+  const DirectedEdge* diredge = tile->directededge(startnodeinfo.edge_index());
+  uint32_t inbound = 0, outbound = 0;
+
+  for (uint32_t i = 0; i < startnodeinfo.edge_count(); i++, diredge++) {
+
+    if ((diredge->forwardaccess() & kAutoAccess) &&
+        !(diredge->reverseaccess() & kAutoAccess))
+      outbound++;
+
+    if (!(diredge->forwardaccess() & kAutoAccess) &&
+        (diredge->reverseaccess() & kAutoAccess))
+      inbound++;
+  }
+
+  if (!outbound && inbound)
+  {
+    const GraphId endnode = directededge.endnode();
+    lock.lock();
+    const GraphTile* tile = reader.GetGraphTile(endnode);
+    lock.unlock();
+    const NodeInfo* nodeinfo = tile->node(endnode.id());
+
+    const DirectedEdge* diredge = tile->directededge(nodeinfo->edge_index());
+    uint32_t inbound = 0, outbound = 0;
+
+    for (uint32_t i = 0; i < nodeinfo->edge_count(); i++, diredge++) {
+
+      if ((diredge->forwardaccess() & kAutoAccess) &&
+          !(diredge->reverseaccess() & kAutoAccess))
+        outbound++;
+
+      if (!(diredge->forwardaccess() & kAutoAccess) &&
+          (diredge->reverseaccess() & kAutoAccess))
+        inbound++;
+    }
+
+    if (!outbound && inbound) {
+      rd.AddTask(startnodeinfo.latlng(),
+                 tilebuilder.edgeinfo(directededge.edgeinfo_offset())->wayid(),
+                 tilebuilder.edgeinfo(directededge.edgeinfo_offset())->shape());
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void AddStatistics(validator_stats& stats, DirectedEdge& directededge,
+                   const uint32_t tileid, std::string& begin_node_iso,
+                   HGVRestrictionTypes& hgv, GraphTileBuilder& tilebuilder,
+                   GraphReader& graph_reader, std::mutex& lock, GraphId& node, NodeInfo& nodeinfo, uint32_t idx) {
+  auto rclass = directededge.classification();
+  float edge_length = (tileid == directededge.endnode().tileid()) ?
+        directededge.length() * 0.5f : directededge.length() * 0.25f;
+
+  // Add truck stats.
+  if (directededge.truck_route()) {
+    stats.add_tile_truck_route(tileid, rclass, edge_length);
+    stats.add_country_truck_route(begin_node_iso, rclass, edge_length);
+  }
+  if (hgv.hazmat) {
+    stats.add_tile_hazmat(tileid, rclass, edge_length);
+    stats.add_country_hazmat(begin_node_iso, rclass, edge_length);
+  }
+  if (hgv.axle_load) {
+    stats.add_tile_axle_load(tileid, rclass);
+    stats.add_country_axle_load(begin_node_iso, rclass);
+  }
+  if (hgv.height) {
+    stats.add_tile_height(tileid, rclass);
+    stats.add_country_height(begin_node_iso, rclass);
+  }
+  if (hgv.length) {
+    stats.add_tile_length(tileid, rclass);
+    stats.add_country_length(begin_node_iso, rclass);
+  }
+  if (hgv.weight) {
+    stats.add_tile_weight(tileid, rclass);
+    stats.add_country_weight(begin_node_iso, rclass);
+  }
+  if (hgv.width) {
+    stats.add_tile_width(tileid, rclass);
+    stats.add_country_width(begin_node_iso, rclass);
+  }
+
+  // Add all other statistics
+  // Only consider edge if edge is good and it's not a link
+  if (!directededge.link()) {
+    //Determine access for directed edge
+    auto fward = ((kAutoAccess & directededge.forwardaccess()) == kAutoAccess);
+    auto bward = ((kAutoAccess & directededge.reverseaccess()) == kAutoAccess);
+    // Check if one way
+    if ((!fward || !bward) && (fward || bward)) {
+      edge_length *= 0.5f;
+      const GraphTile* tile = graph_reader.GetGraphTile(node);
+      bool found = IsPedestrianTerminal(tilebuilder,graph_reader,lock,node,nodeinfo,directededge,stats.roulette_data,idx);
+      if (!found && directededge.endnode().id() == node.id()) {
+        lock.lock();
+        const GraphTile* end_tile = graph_reader.GetGraphTile(directededge.endnode());
+        lock.unlock();
+        if (tile->id() == end_tile->id())
+          found = IsLoopTerminal(tilebuilder,graph_reader,lock,node,nodeinfo,directededge,stats.roulette_data);
+      }
+      if (!found && directededge.endnode().id() != node.id()) {
+        found = IsReversedOneway(tilebuilder,graph_reader,lock,node,nodeinfo,directededge,stats.roulette_data);
+      }
+      stats.add_tile_one_way(tileid, rclass, edge_length);
+      stats.add_country_one_way(begin_node_iso, rclass, edge_length);
+    }
+    // Check if this edge is internal
+    if (directededge.internal()) {
+      stats.add_tile_int_edge(tileid, rclass);
+      stats.add_country_int_edge(begin_node_iso, rclass);
+    }
+    // Check if edge has maxspeed tag
+    if (directededge.speed_type() == SpeedType::kTagged){
+      stats.add_tile_speed_info(tileid, rclass, edge_length);
+      stats.add_country_speed_info(begin_node_iso, rclass, edge_length);
+    }
+    // Check if edge has any names
+    if (tilebuilder.edgeinfo(directededge.edgeinfo_offset())->name_count() > 0) {
+      stats.add_tile_named(tileid, rclass, edge_length);
+      stats.add_country_named(begin_node_iso, rclass, edge_length);
+    }
+
+    // Add road lengths to statistics for current country and tile
+    stats.add_country_road(begin_node_iso, rclass, edge_length);
+    stats.add_tile_road(tileid, rclass, edge_length);
   }
 }
 
-/*
- * Callback function that gets the column names from the database
- */
-static int classCallback (void *data, int argc, char **argv, char **colName) {
-  std::vector<std::string> *cat = (std::vector<std::string>*) data;
-  for (int i = 1; i < argc; ++i) {
-    cat->push_back(colName[i]);
+void build(const boost::property_tree::ptree& pt,
+              std::deque<GraphId>& tilequeue, std::mutex& lock,
+              std::promise<validator_stats>& result) {
+
+    // Our local class for gathering the stats
+    validator_stats stats;
+    // Local Graphreader
+    GraphReader graph_reader(pt.get_child("mjolnir"));
+    // Get some things we need throughout
+    const auto& hierarchy = graph_reader.GetTileHierarchy();
+
+    // Check for more tiles
+    while (true) {
+      lock.lock();
+      if (tilequeue.empty()) {
+        lock.unlock();
+        break;
+      }
+      // Get the next tile Id
+      GraphId tile_id = tilequeue.front();
+      tilequeue.pop_front();
+      lock.unlock();
+
+      // Point tiles to the set we need for current level
+      auto level = tile_id.level();
+      if (hierarchy.levels().rbegin()->second.level+1 == level)
+        level = hierarchy.levels().rbegin()->second.level;
+
+      const auto& tiles = hierarchy.levels().find(level)->second.tiles;
+      level = tile_id.level();
+      auto tileid = tile_id.tileid();
+
+      // Get the tile
+      GraphTileBuilder tilebuilder(hierarchy, tile_id, false);
+
+      // Update nodes and directed edges as needed
+      std::vector<NodeInfo> nodes;
+      std::vector<DirectedEdge> directededges;
+
+      // Get this tile
+      lock.lock();
+      const GraphTile* tile = graph_reader.GetGraphTile(tile_id);
+      lock.unlock();
+
+      // Iterate through the nodes and the directed edges
+      float roadlength = 0.0f;
+      uint32_t nodecount = tilebuilder.header()->nodecount();
+      GraphId node = tile_id;
+      for (uint32_t i = 0; i < nodecount; i++, node++) {
+        // The node we will modify
+        NodeInfo nodeinfo = tilebuilder.node(i);
+        auto ni = tile->node(i);
+        std::string begin_node_iso = tile->admin(nodeinfo.admin_index())->country_iso();
+
+        // Go through directed edges
+        uint32_t idx = ni->edge_index();
+        for (uint32_t j = 0, n = nodeinfo.edge_count(); j < n; j++, idx++) {
+          auto de = tile->directededge(idx);
+
+          // HGV restriction mask (for stats)
+          HGVRestrictionTypes hgv = {};
+
+          // check access restrictions. TODO - should check modes as well
+          uint32_t ar_modes = de->access_restriction();
+          if (ar_modes) {
+            //since only truck restrictions exist, we can still get all restrictions
+            //later we may only want to get just the truck ones for stats.
+            auto res = tile->GetAccessRestrictions(idx, kAllAccess);
+            if (res.size() == 0) {
+              LOG_ERROR("Directed edge marked as having access restriction but none found ; tile level = " +
+                  std::to_string(tile_id.level()));
+            } else {
+              for (auto r : res) {
+                if (r.edgeindex() != idx) {
+                  LOG_ERROR("Access restriction edge index does not match idx");
+                } else {
+                  switch (r.type()) {
+                    case AccessType::kHazmat:
+                      hgv.hazmat = true;
+                      break;
+                    case AccessType::kMaxAxleLoad:
+                      hgv.axle_load = true;
+                      break;
+                    case AccessType::kMaxHeight:
+                      hgv.height = true;
+                      break;
+                    case AccessType::kMaxLength:
+                      hgv.length = true;
+                      break;
+                    case AccessType::kMaxWeight:
+                      hgv.weight = true;
+                      break;
+                    case AccessType::kMaxWidth:
+                      hgv.width = true;
+                      break;
+                    default:
+                      break;
+                  }
+                }
+              }
+            }
+          }
+          // The edge we will modify
+          DirectedEdge& directededge = tilebuilder.directededge(nodeinfo.edge_index() + j);
+
+          // Road Length and some variables for statistics
+          float edge_length;
+          bool valid_length = false;
+          if (!directededge.shortcut() && !directededge.trans_up() &&
+              !directededge.trans_down()) {
+            edge_length = directededge.length();
+            roadlength += edge_length;
+            valid_length = true;
+          }
+
+          // Statistics
+          if (valid_length) {
+            AddStatistics(stats, directededge, tileid, begin_node_iso,
+                          hgv, tilebuilder, graph_reader, lock, node, nodeinfo, j);
+          }
+        }
+
+        // Add the node to the list
+        nodes.emplace_back(std::move(nodeinfo));
+      }
+
+      // Add density to return class. Approximate the tile area square km
+      AABB2<PointLL> bb = tiles.TileBounds(tileid);
+      float area = ((bb.maxy() - bb.miny()) * kMetersPerDegreeLat * kKmPerMeter) *
+                   ((bb.maxx() - bb.minx()) *
+                     DistanceApproximator::MetersPerLngDegree(bb.Center().y()) * kKmPerMeter);
+      stats.add_tile_area(tileid, area);
+      stats.add_tile_geom(tileid, tiles.TileBounds(tileid));
+
+
+      // Check if we need to clear the tile cache
+      lock.lock();
+      if (graph_reader.OverCommitted())
+        graph_reader.Clear();
+      lock.unlock();
+    }
+
+    // Fill promise with statistics
+    result.set_value(std::move(stats));
   }
-  cat->push_back("total");
-  return 0;
 }
 
-/*
- * Queries the database to get road class types
- * Params
- *  *db - sqlite3 database connection object
- *  classes - a vector of strings representing the road types
- *
- * Post
- *  The array containing the road classes is filled
- */
-void fillClasses(sqlite3 *db, std::vector<std::string>& classes) {
- 
-  std::string sql = "SELECT * FROM countrydata LIMIT 1";
-  char *errMsg = 0;
-  int rc = sqlite3_exec(db, sql.c_str(), classCallback, (void*) &classes, &errMsg);
-  checkDBResponse(rc, errMsg);
-}
+void BuildStatistics(const boost::property_tree::ptree& pt) {
 
-/*
- * Callback function to reveive query results from sqlite3_exec
- * Params
- *  *dataPair - the pointer used to pass data structures into this function
- *  argc - # arguments
- *  **argv - char array of arguments
- *  **colName - char array returned column names from the database
- */
-static int countryDataCallback (void *data_pair, int argc, char **argv, char **colName) {
-  dataPair* p = (dataPair*) data_pair;
-  auto* countries = std::get<0>(*p);
-  auto* data = std::get<1>(*p);
+  // Graphreader
+  TileHierarchy hierarchy(pt.get<std::string>("mjolnir.tile_dir"));
+  // Make sure there are at least 2 levels!
+  if (hierarchy.levels().size() < 2)
+    throw std::runtime_error("Bad tile hierarchy - need 2 levels");
 
-  countries->push_back(argv[0]);
-  std::string line = "";
-  for (int i = 1; i < argc; ++i) {
-    line += argv[i];
-    line += " ";
+  // Create a randomized queue of tiles to work from
+  std::deque<GraphId> tilequeue;
+  for (auto tier : hierarchy.levels()) {
+    auto level = tier.second.level;
+    auto tiles = tier.second.tiles;
+    for (uint32_t id = 0; id < tiles.TileCount(); id++) {
+      // If tile exists add it to the queue
+      GraphId tile_id(id, level, 0);
+      if (GraphReader::DoesTileExist(hierarchy, tile_id)) {
+        tilequeue.emplace_back(std::move(tile_id));
+      }
+    }
+
+    //transit level
+    if (level == hierarchy.levels().rbegin()->second.level) {
+      level += 1;
+      for (uint32_t id = 0; id < tiles.TileCount(); id++) {
+        // If tile exists add it to the queue
+        GraphId tile_id(id, level, 0);
+        if (GraphReader::DoesTileExist(hierarchy, tile_id)) {
+          tilequeue.emplace_back(std::move(tile_id));
+        }
+      }
+    }
+  }
+  std::random_shuffle(tilequeue.begin(), tilequeue.end());
+
+  // A mutex we can use to do the synchronization
+  std::mutex lock;
+
+  LOG_INFO("Gathering information about the tiles in " + pt.get<std::string>("mjolnir.tile_dir"));
+
+  // Setup threads
+  std::vector<std::shared_ptr<std::thread> > threads(
+      std::max(static_cast<unsigned int>(1),
+               pt.get<unsigned int>("concurrency",std::thread::hardware_concurrency())));
+
+  // Setup promises
+  std::list<std::promise<validator_stats> > results;
+
+  // Spawn the threads
+  for (auto& thread : threads) {
+    results.emplace_back();
+    thread.reset(new std::thread(build, std::cref(pt), std::ref(tilequeue),
+                                 std::ref(lock), std::ref(results.back())));
   }
 
-  std::istringstream iss(line);
-  float tok = 0;
-  float sum = 0;
-  std::vector<float> *classData = new std::vector<float>();
-
-  while (iss >> tok) {
-    classData->push_back(tok);
-    sum += tok;
+  // Wait for threads to finish
+  for (auto& thread : threads)
+    thread->join();
+  // Get the promise from the future
+  validator_stats stats;
+  for (auto& result : results) {
+    auto r = result.get_future().get();
+    //keep track of stats
+    stats.add(r);
   }
-  classData->push_back(sum);
-  data->emplace(argv[0], *classData);
+  LOG_INFO("Finished");
 
-  return 0;
+  stats.build_db(pt);
+  stats.roulette_data.GenerateTasks();
 }
 
-/*
- * Queries the database to get length of roads in each class per country
- * Params
- *  *db - sqlite3 database connection object
- *  countries - vector of country iso codes
- *  data - 2D vector of road lengths
- *    each column belongs to a certain country
- *    each row is a type of road
- * Post
- *  countries contains the iso codes of all countries in the database
- *  data contains the lengths of each type of road for each country
- */
-void fillCountryData(sqlite3 *db, std::vector<std::string>& countries, std::unordered_map<std::string, std::vector<float>>& data) {
- 
-  std::string sql = "SELECT * FROM countrydata WHERE isocode IS NOT \"\"";
-
-  char *errMsg = 0;
-  dataPair data_pair = {&countries, &data};
-  int rc = sqlite3_exec(db, sql.c_str(), countryDataCallback, (void*) &data_pair, &errMsg);
-  checkDBResponse(rc, errMsg);
-}
-
-/* 
- * Callback function to receive query results from sqlite3_exec
- * Params
- *  *dataPair - the pointer used to pass data structures into this function
- *  argc - # arguments
- *  **argv - char array of arguments
- *  **colName - char array returned column names from the database
- */
-static int maxSpeedCallback (void *data, int argc, char **argv, char **colName) {
-  auto* maxSpeedInfo =
-    (std::unordered_map<std::string, std::vector<float>>*) data;
-  
-  std::istringstream ss(argv[2]);
-  float val;
-  ss >> val;
-
-  maxSpeedInfo->at(argv[0]).push_back(val);
-
-  return 0;
-}
-
-/*
- * Retrieves the maxspeed data from the database and fills the data structure
- */
-void fillMaxSpeedData(sqlite3* db, std::unordered_map<std::string, std::vector<float>>& maxSpeedInfo) {
- 
-  std::string sql = "SELECT isocode,type,maxspeed";
-  sql += " FROM rclassctrydata";
-  sql += " WHERE (type='Motorway' OR type='Primary' OR type='Secondary' OR type='Trunk')";
-  sql += " AND isocode IS NOT \"\"";
-
-  char *errMsg = 0;
-  int rc = sqlite3_exec(db, sql.c_str(), maxSpeedCallback, (void*) &maxSpeedInfo, &errMsg);
-  checkDBResponse(rc, errMsg);
-}
-
-/* 
- * Callback function to receive query results from sqlite3_exec
- * Params
- *  *data - the pointer used to pass data structures into this function
- *  argc - # arguments
- *  **argv - char array of arguments
- *  **colName - char array returned column names from the database
- */
-static int namedCallback (void *data, int argc, char **argv, char **colName) {
-  auto* namedInfo =
-    (std::unordered_map<std::string, std::vector<float>>*) data;
-  
-  std::istringstream ss(argv[2]);
-  float val;
-  ss >> val;
-
-  namedInfo->at(argv[0]).push_back(val);
-
-  return 0;
-}
-
-/*
- * Retrieves the named road data from the database and fills the data structure
- */
-void fillNamedData(sqlite3* db, std::unordered_map<std::string, std::vector<float>>& namedInfo) {
- 
-  std::string sql = "SELECT isocode,type,named";
-  sql += " FROM rclassctrydata";
-  sql += " WHERE (type='Residential' OR type='Unclassified')";
-  sql += " AND isocode IS NOT \"\"";
-
-  char *errMsg = 0;
-  int rc = sqlite3_exec(db, sql.c_str(), namedCallback, (void*) &namedInfo, &errMsg);
-  checkDBResponse(rc, errMsg);
-}
-/*
- * Generates a javascript file that has a function to return
- *  all the data queried from the database
- * Params
- *  countries - names of all the countries from the database
- *  data - float values for all the lengths of road per country
- *  classes - the types of road classes
- *  maxClasses - types of road data which have corresponding maxspeed data
- *  maxSpeedInfo - float values for each maxClass for each country
- */
-void generateJson (std::vector<std::string>& countries,
-                   std::unordered_map<std::string, std::vector<float>>& data,
-                   std::vector<std::string>& classes,
-                   std::unordered_map<std::string, std::vector<float>>& maxSpeedInfo,
-                   std::vector<std::string>& maxClasses,
-                   std::unordered_map<std::string, std::vector<float>>& namedInfo,
-                   std::vector<std::string>& namedClasses) {
-
-  using namespace valhalla::baldr;
-
-  std::ofstream out ("road_data.json");
-  json::MapPtr map = json::map({});
-  for (size_t i = 0; i < countries.size(); ++i) {
-    map->emplace(
-      countries[i], json::map
-      ({
-        {"iso2", countries[i]},
-        {"classinfo", json::map
-        ({
-         {classes[0], json::fp_t{data[countries[i]][0]}},
-         {classes[1], json::fp_t{data[countries[i]][1]}},
-         {classes[2], json::fp_t{data[countries[i]][2]}},
-         {classes[3], json::fp_t{data[countries[i]][3]}},
-         {classes[4], json::fp_t{data[countries[i]][4]}},
-         {classes[5], json::fp_t{data[countries[i]][5]}},
-         {classes[6], json::fp_t{data[countries[i]][6]}},
-         {classes[7], json::fp_t{data[countries[i]][7]}},
-         {classes[8], json::fp_t{data[countries[i]][8]}}
-        })},
-        {"maxspeed", json::map
-        ({
-         {maxClasses[0], json::fp_t{maxSpeedInfo[countries[i]][0]}},
-         {maxClasses[1], json::fp_t{maxSpeedInfo[countries[i]][1]}},
-         {maxClasses[2], json::fp_t{maxSpeedInfo[countries[i]][2]}},
-         {maxClasses[3], json::fp_t{maxSpeedInfo[countries[i]][3]}}
-        })},
-        {"named", json::map
-        ({
-         {namedClasses[0], json::fp_t{namedInfo[countries[i]][0]}},
-         {namedClasses[1], json::fp_t{namedInfo[countries[i]][1]}},
-        })}
-      })
-    );
+bool ParseArguments(int argc, char *argv[]) {
+  bpo::options_description options("Usage: valhalla_build_statistics --config conf/valhalla.json");
+  options.add_options()
+    ("help,h", "Print this help message")
+    ("config,c",
+     boost::program_options::value<boost::filesystem::path>(&config_file_path)->required(),
+     "Path to the json configuration file.");
+  bpo::variables_map vm;
+  try {
+    bpo::store(bpo::command_line_parser(argc, argv).options(options).run(), vm);
+    bpo::notify(vm);
+  } catch (std::exception& e) {
+    std::cerr << "Unable to parse command line options because: " << e.what() << "\n";
+    return false;
   }
-  out << *map << std::endl;
 
-  out.close();
+  if (vm.count("help")) {
+    std::cout << options << "\n";
+    return true;
+  }
+  if (vm.count("config")) {
+    if (boost::filesystem::is_regular_file(config_file_path))
+      return true;
+    else
+      std::cerr << "Configuration file is required\n\n" << options << "\n\n";
+  }
+
+  return false;
 }
 
 int main (int argc, char** argv) {
-  // If there is no input file print and error and exit
-  if (argc < 2) {
-    std::cout << "ERROR: No input file specified." << std::endl;
-    std::cout << "Usage: " << argv[0] << " statistics.sqlite" << std::endl;
-    exit(0);
+  if (!ParseArguments(argc, argv))
+    return EXIT_FAILURE;
+
+  // check the type of input
+  boost::property_tree::ptree pt;
+  boost::property_tree::read_json(config_file_path.c_str(), pt);
+
+  //configure loggin
+  boost::optional<boost::property_tree::ptree&> logging_subtree = pt.get_child_optional("mjolnir.logging");
+  if (logging_subtree) {
+    auto loggin_config = valhalla::midgard::ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string> >(logging_subtree.get());
+    valhalla::midgard::logging::Configure(loggin_config);
   }
 
-  // data structures
-  std::vector<std::string> roadClasses;
-  std::vector<std::string> countries;
-  std::unordered_map<std::string, std::vector<float>> roadClassInfo;
-  // speed info
-  std::vector<std::string> maxClasses = {"Motorway", "Primary", "Secondary", "Trunk"};
-  std::unordered_map<std::string, std::vector<float>> maxSpeedInfo;
-  // name info
-  std::vector<std::string> namedClasses = {"Residential", "Unclassified"};
-  std::unordered_map<std::string, std::vector<float>> namedInfo;
+  //set up directory
+  auto tile_dir = pt.get<std::string>("mjolnir.tile_dir");
+  valhalla::baldr::TileHierarchy hierarchy(tile_dir);
 
-  // open DB file
-  sqlite3 *db;
-  int rc = sqlite3_open(argv[1], &db);
-  if ( rc ) {
-    std::cout << "Opening DB failed: " << sqlite3_errmsg(db);
-    exit(0);
-  }
+  BuildStatistics(pt);
 
-  // fill data structures
-  fillClasses(db, roadClasses);
-  fillCountryData(db, countries, roadClassInfo);
-  // create the entries in the map
-  for (auto& s : countries) {
-    maxSpeedInfo[s];
-    namedInfo[s];
-  }
-  fillMaxSpeedData(db, maxSpeedInfo);
-  fillNamedData(db, namedInfo);
- 
-  generateJson(countries, roadClassInfo, roadClasses,
-               maxSpeedInfo, maxClasses,
-               namedInfo, namedClasses);
- 
-  sqlite3_close(db);
-  return 0;
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Do not create shortcut at a node where the continuation along the same named road might be at a 'T' intersection or a turn in presence of other driveable roads. Creating a shortcut across these nodes will remove maneuvers that should be called out in the guidance/narrative.

Also, add an application to create real-time speed tiles from way Id and speed CSV files. This was used in a traffic proof of concept.