### PR TITLE
Build timezones cleanup

### DIFF
--- a/scripts/valhalla_build_timezones
+++ b/scripts/valhalla_build_timezones
@@ -37,7 +37,7 @@ rm -f $tz_file
 url="http://efele.net/maps/tz/world/tz_world_mp.zip"
 wget $url || error_exit "wget failed for " $url
 unzip ./tz_world_mp.zip || error_exit "unzip failed"
-spatialite_tool -i -shp ./world/tz_world_mp -d $tz_file -t tz_world -s 4326 -g geom -c UTF8 || error_exit "spatialite_tool import failed"
+spatialite_tool -i -shp ./world/tz_world_mp -d $tz_file -t tz_world -s 4326 -g geom -c UTF-8 || error_exit "spatialite_tool import failed"
 spatialite $tz_file "SELECT CreateSpatialIndex('tz_world', 'geom');" || error_exit "SpatialIndex failed" 
 
 rm -rf world

--- a/scripts/valhalla_build_timezones
+++ b/scripts/valhalla_build_timezones
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-function error_exit
-{
+error_exit() {
   echo "$1" 1>&2
   exit 1
 }

--- a/scripts/valhalla_build_timezones
+++ b/scripts/valhalla_build_timezones
@@ -6,7 +6,7 @@ error_exit() {
 }
 
 if [ -z "$1" ]; then
-    echo "No config supplied.  Usage: ./create_tz_db.sh /data/valhalla/mjolnir/conf/valhalla.json"
+    echo "No config supplied.  Usage: valhalla_build_timezones /data/valhalla/mjolnir/conf/valhalla.json"
     exit 1
 fi
 


### PR DESCRIPTION
UTF8 is not a valid synonym for UTF-8 ([see this spatialite thread](https://groups.google.com/d/msg/spatialite-users/ecjs56lzQRA/OF7Ie5UuEvsJ)). It results in the following error on OpenBSD:

    SpatiaLite version: 4.3.0a
    load shapefile error: cannot open shapefile './world/tz_world_mp'
            cause: conversion from 'UTF8' to 'UTF-8' not available
    
    Some ERROR occurred
    SpatiaLite version ..: 4.3.0a   Supported Extensions:
            - 'VirtualShape'        [direct Shapefile access]
            - 'VirtualDbf'          [direct DBF access]
            - 'VirtualXL'           [direct XLS access]
            - 'VirtualText'         [direct CSV/TXT access]
            - 'VirtualNetwork'      [Dijkstra shortest path]
            - 'RTree'               [Spatial Index - R*Tree]
            - 'MbrCache'            [Spatial Index - MBR cache]
            - 'VirtualSpatialIndex' [R*Tree metahandler]
            - 'VirtualElementary'   [ElemGeoms metahandler]
            - 'VirtualXPath'        [XML Path Language - XPath]
            - 'VirtualFDO'          [FDO-OGR interoperability]
            - 'VirtualGPKG' [OGC GeoPackage interoperability]
            - 'VirtualBBox'         [BoundingBox tables]
            - 'SpatiaLite'          [Spatial SQL - OGC]
    PROJ.4 version ......: Rel. 4.9.2, 08 September 2015
    GEOS version ........: 3.5.0-CAPI-1.9.0 r4084
    TARGET CPU ..........: amd64-unknown-openbsd6.0
    CreateSpatialIndex() error: either "tz_world"."geom" isn't a Geometry column or a SpatialIndex is already defined
    0

While here, clean up a couple of small nits in the script.