### PR TITLE
Set flag for dead end directed edge

### DIFF
--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -1174,6 +1174,8 @@ void enhance(const boost::property_tree::ptree& pt,
 
       // Set the intersection type
       if (nodeinfo.edge_count() == 1) {
+        // TODO - does this need to be a count of driveable edges
+        // (e.g. a node that has 1 driveable edge and a walkway?)
         nodeinfo.set_intersection(IntersectionType::kDeadEnd);
       } else if (nodeinfo.edge_count() == 2) {
         if (nodeinfo.type() == NodeType::kGate ||


### PR DESCRIPTION
This is based on the node intersection typebeing kDeadEnd. May need to revisit the setting of the node to dead end to consider if only 1 driveable edge exists.