### PR TITLE
Protect against 0 length edges.

### DIFF
--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -8,6 +8,8 @@ using namespace valhalla::baldr;
 namespace valhalla {
 namespace mjolnir {
 
+constexpr uint32_t kMinimumEdgeLength = 1;
+
 // Constructor with parameters
 DirectedEdgeBuilder::DirectedEdgeBuilder(
                    const OSMWay& way, const GraphId& endnode,
@@ -18,10 +20,12 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(
                    const uint32_t restrictions, const uint32_t bike_network)
      :  DirectedEdge() {
   set_endnode(endnode);
-  set_length(length);
   set_use(use);
-  set_speed(speed);    // KPH
+  set_speed(speed);             // KPH
   set_truck_speed(truck_speed); // KPH
+
+  // Protect against 0 length edges
+  set_length(std::max(length, kMinimumEdgeLength));
 
   // Override use for ferries/rail ferries. TODO - set this in lua
   if (way.ferry()) {

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -35,6 +35,9 @@ namespace {
 //how many meters to resample shape to when checking elevations
 constexpr double POSTING_INTERVAL = 60.0;
 
+// Do not compute grade for intervals less than 10 meters.
+constexpr double kMinimumInterval = 10.0f;
+
 // Simple structure to describe a connection between 2 levels
 struct NodeConnection {
   GraphId basenode;
@@ -354,6 +357,11 @@ bool IsEnteringEdgeOfContractedNode(const GraphId& node, const GraphId& edge,
 
 std::tuple<double, double, double> GetGrade(const std::unique_ptr<const valhalla::skadi::sample>& sample,
                     const std::list<PointLL>& shape, const float length, const bool forward) {
+  // For very short lengths just return 0 grades
+  if (length < kMinimumInterval) {
+    return std::make_tuple(0.0, 0.0, 0.0);
+  }
+
   //evenly sample the shape
   std::list<PointLL> resampled;
   //if it was really short just do both ends


### PR DESCRIPTION
Do not compute grade for ferries and for short edges.