### PR TITLE
support vehicle_type: tram_service and vehicle_type: local_bus_service

### DIFF
--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -190,7 +190,12 @@ std::priority_queue<weighted_tile_t> which_tiles(const ptree& pt) {
   const auto& tile_level = hierarchy.levels().rbegin()->second;
   curler_t curler;
   auto feeds = curler(url("/api/v1/feeds.geojson?", pt), "features");
+
   for(const auto& feature : feeds.get_child("features")) {
+    //use the following logic if you only want certain feeds
+    //auto feed = feature.second.get_optional<std::string>("properties.onestop_id");
+    //if (feed && *feed == "f-9q9-bart")
+
     //should be a polygon
     auto type = feature.second.get_optional<std::string>("geometry.type");
     if(!type || *type != "Polygon") {
@@ -298,13 +303,14 @@ void get_routes(Transit& tile, std::unordered_map<std::string, size_t>& routes,
     set_no_null(std::string, route_pt.second, "onestop_id", "null", route->set_onestop_id);
     std::string vehicle_type = route_pt.second.get<std::string>("vehicle_type", "null");
     Transit_VehicleType type = Transit_VehicleType::Transit_VehicleType_kRail;
-    if (vehicle_type == "tram")
+    if (vehicle_type == "tram" || vehicle_type == "tram_service")
       type = Transit_VehicleType::Transit_VehicleType_kTram;
     else if (vehicle_type == "metro")
       type = Transit_VehicleType::Transit_VehicleType_kMetro;
     else if (vehicle_type == "rail")
       type = Transit_VehicleType::Transit_VehicleType_kRail;
-    else if (vehicle_type == "bus" || vehicle_type == "trolleybus_service" || vehicle_type == "express_bus_service")
+    else if (vehicle_type == "bus" || vehicle_type == "trolleybus_service" ||
+             vehicle_type == "express_bus_service" || vehicle_type == "local_bus_service")
       type = Transit_VehicleType::Transit_VehicleType_kBus;
     else if (vehicle_type == "ferry")
       type = Transit_VehicleType::Transit_VehicleType_kFerry;
@@ -1243,6 +1249,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
     GraphId stopid = stop_edges.second.origin_pbf_graphid;
     uint32_t stop_index = stopid.id();
     const Transit_Stop& stop = transit.stops(stop_index);
+
     if (GraphId(stop.graphid()) != stopid) {
       LOG_ERROR("Stop key not equal!");
     }

--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -190,7 +190,6 @@ std::priority_queue<weighted_tile_t> which_tiles(const ptree& pt) {
   const auto& tile_level = hierarchy.levels().rbegin()->second;
   curler_t curler;
   auto feeds = curler(url("/api/v1/feeds.geojson?", pt), "features");
-
   for(const auto& feature : feeds.get_child("features")) {
     //use the following logic if you only want certain feeds
     //auto feed = feature.second.get_optional<std::string>("properties.onestop_id");
@@ -1249,7 +1248,6 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
     GraphId stopid = stop_edges.second.origin_pbf_graphid;
     uint32_t stop_index = stopid.id();
     const Transit_Stop& stop = transit.stops(stop_index);
-
     if (GraphId(stop.graphid()) != stopid) {
       LOG_ERROR("Stop key not equal!");
     }


### PR DESCRIPTION
Added logic to support vehicle_type: tram_service and vehicle_type: local_bus_service.  Lots of errors in transit log.

2016/09/13 07:15:23.061305 [ERROR] Skipping unsupported vehicle_type: tram_service for route r-u0y1j-24
2016/09/13 07:15:23.061344 [ERROR] Skipping unsupported vehicle_type: tram_service for route r-u0y1-1
2016/09/13 07:15:23.061355 [ERROR] Skipping unsupported vehicle_type: tram_service for route r-u0y1j-26
2016/09/13 07:15:23.061364 [ERROR] Skipping unsupported vehicle_type: local_bus_service for route r-u0y0v-27
2016/09/13 07:15:23.061373 [ERROR] Skipping unsupported vehicle_type: tram_service for route r-u0y1j-22
2016/09/13 07:15:23.061382 [ERROR] Skipping unsupported vehicle_type: tram_service for route r-u0y0v-23
2016/09/13 07:15:23.061404 [ERROR] Skipping unsupported vehicle_type: local_bus_service for route r-u0y0vt-28
2016/09/13 07:15:23.061414 [ERROR] Skipping unsupported vehicle_type: local_bus_service for route r-u0y0v-29
2016/09/13 07:15:23.061423 [ERROR] Skipping unsupported vehicle_type: tram_service for route r-u0y1-8
2016/09/13 07:15:23.061432 [ERROR] Skipping unsupported vehicle_type: tram_service for route r-u0y1-7
2016/09/13 07:15:23.061441 [ERROR] Skipping unsupported vehicle_type: local_bus_service for route r-u0y19-58
2016/09/13 07:15:23.061450 [ERROR] Skipping unsupported vehicle_type: local_bus_service for route r-u0y1d-57
2016/09/13 07:15:23.061459 [ERROR] Skipping unsupported vehicle_type: local_bus_service for route r-u0y19-50