### PR TITLE
Make it working on debian jessie

### DIFF
--- a/src/mjolnir/admin.cc
+++ b/src/mjolnir/admin.cc
@@ -27,7 +27,7 @@ sqlite3 * GetDBHandle(const std::string& database) {
 
     // loading SpatiaLite as an extension
     sqlite3_enable_load_extension(db_handle, 1);
-#if SQLITE_VERSION_NUMBER > 3008002
+#if SQLITE_VERSION_NUMBER > 3008007
     sql = "SELECT load_extension('mod_spatialite')";
 #else
     sql = "SELECT load_extension('libspatialite')";

--- a/src/mjolnir/statistics_database.cc
+++ b/src/mjolnir/statistics_database.cc
@@ -38,7 +38,7 @@ void statistics::build_db(const boost::property_tree::ptree& pt) {
 
   // loading SpatiaLite as an extension
   sqlite3_enable_load_extension(db_handle, 1);
-#if SQLITE_VERSION_NUMBER > 3008002
+#if SQLITE_VERSION_NUMBER > 3008007
     sql = "SELECT load_extension('mod_spatialite')";
 #else
     sql = "SELECT load_extension('libspatialite')";

--- a/src/mjolnir/valhalla_benchmark_admins.cc
+++ b/src/mjolnir/valhalla_benchmark_admins.cc
@@ -164,7 +164,7 @@ std::cout << "In Benchmark" << std::endl;
 
     // loading SpatiaLite as an extension
     sqlite3_enable_load_extension(db_handle, 1);
-#if SQLITE_VERSION_NUMBER > 3008002
+#if SQLITE_VERSION_NUMBER > 3008007
     sql = "SELECT load_extension('mod_spatialite')";
 #else
     sql = "SELECT load_extension('libspatialite')";

--- a/src/mjolnir/valhalla_build_admins.cc
+++ b/src/mjolnir/valhalla_build_admins.cc
@@ -284,7 +284,7 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
 
   // loading SpatiaLite as an extension
   sqlite3_enable_load_extension(db_handle, 1);
-#if SQLITE_VERSION_NUMBER > 3008002
+#if SQLITE_VERSION_NUMBER > 3008007
     sql = "SELECT load_extension('mod_spatialite')";
 #else
     sql = "SELECT load_extension('libspatialite')";


### PR DESCRIPTION
`valhalla_build_admins` is not working on Debian Jessie (current stable). This PR corrects that. But the solution is not perfect.

At libspatialite >= 4.2, `SELECT load_extension('libspatialite')` is replaced by `SELECT load_extension('mod_spatialite')`. Mjolnir was choosing between the two by checking sqlite3>3.8.2 (corresponding to the version of sqlite3 in trusty).

But Debian Jessie has sqlite=3.8.7.1 and libspatialite=4.1.1. Thus, `valhalla_build_admins` is not working.

Here are the version of ubuntu and debian:

|Distribution|Version|sqlite3|libspatialite|
|-------------|----------|--------|---------------|
|Ubuntu|precise|3.7.9|3.0.0|
|Debian|wheezy|3.7.13|3.0.0|
|Ubuntu|trusty|3.8.2|4.1.1|
|Debian|jessie|3.8.7.1|4.1.1|
|Ubuntu|wily|3.8.11.1|4.3.0|
|Ubuntu|xenial|3.11.0|4.3.0a|
|Ubuntu|yakkety|3.14.1|4.3.0a|
|Debian|stretch|3.14.1|4.3.0a|

This PR propose to use `mod_spatialite` if sqlite>3.8.7.*. That's not perfect, but better than now.