### PR TITLE
access updates for transit. 

### DIFF
--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -114,6 +114,8 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
                 const TileHierarchy& hierarchy_transit,
                 const std::string& transit_dir,
                 const GraphTile* tile,
+                GraphReader& reader_transit_level,
+                std::mutex& lock,
                 const std::unordered_set<GraphId>& tiles,
                 const std::vector<OSMConnectionEdge>& connection_edges) {
   auto t1 = std::chrono::high_resolution_clock::now();
@@ -183,6 +185,7 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
     // Add directed edges for any connections from the OSM node
     // to a transit stop
     // level 2
+    const GraphTile* end_tile = nullptr;
     while (added_edges < connection_edges.size() &&
            connection_edges[added_edges].osm_node.id() == nodeid) {
       const OSMConnectionEdge& conn = connection_edges[added_edges];
@@ -193,6 +196,14 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
         continue;
       }
 
+      if (!end_tile || (end_tile->id().Tile_Base() != endnode.Tile_Base())) {
+        lock.lock();
+        end_tile = reader_transit_level.GetGraphTile(endnode);
+        lock.unlock();
+      }
+      //use the access from the transit end node
+      const auto& tc_access = end_tile->node(endnode)->access();
+
       DirectedEdge directededge;
       directededge.set_endnode(endnode);
       directededge.set_length(conn.length);
@@ -200,8 +211,8 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
       directededge.set_speed(5);
       directededge.set_classification(RoadClass::kServiceOther);
       directededge.set_localedgeidx(tilebuilder_local.directededges().size() - edge_index);
-      directededge.set_forwardaccess(kPedestrianAccess);  // TODO - bikes?
-      directededge.set_reverseaccess(kPedestrianAccess);  // TODO - bikes?
+      directededge.set_forwardaccess(tc_access);
+      directededge.set_reverseaccess(tc_access);
 
       // Add edge info to the tile and set the offset in the directed edge
       bool added = false;
@@ -276,17 +287,8 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
         if (!origin_node.Is_Valid()) {
           continue;
         }
-
-        // Build the node info. Use generic transit stop type
-        uint32_t access = kPedestrianAccess;
-        /** TODO bicycle access
-        auto s_access = stop_access.find(stop.pbf_graphid);
-        if (s_access != stop_access.end()) {
-          if (s_access->second)
-            access |= kBicycleAccess;
-        }
-        **/
-
+        //use the access from the transit node
+        const auto& tc_access = nb.access();
         DirectedEdge directededge;
         directededge.set_endnode(conn.osm_node);
         directededge.set_length(conn.length);
@@ -294,8 +296,8 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
         directededge.set_speed(5);
         directededge.set_classification(RoadClass::kServiceOther);
         directededge.set_localedgeidx(tilebuilder_transit.directededges().size() - edge_index);
-        directededge.set_forwardaccess(kPedestrianAccess);  // TODO - bikes?
-        directededge.set_reverseaccess(kPedestrianAccess);  // TODO - bikes?
+        directededge.set_forwardaccess(tc_access);
+        directededge.set_reverseaccess(tc_access);
 
         // Add edge info to the tile and set the offset in the directed edge
         bool added = false;
@@ -327,6 +329,9 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
     }
     // Add the node and directed edges
     nb.set_edge_index(edge_index);
+
+    //reset the access to defaults.
+    nb.set_access((kPedestrianAccess | kWheelchairAccess | kBicycleAccess));
     nb.set_edge_count(tilebuilder_transit.directededges().size() - edge_index);
     tilebuilder_transit.nodes().emplace_back(std::move(nb));
   }
@@ -350,7 +355,6 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
 // Add connection edges from the transit stop to an OSM edge
 void AddOSMConnection(const Transit_Stop& stop, const GraphTile* tile,
                       const TileHierarchy& tilehierarchy,
-                      GraphReader& reader,
                       std::mutex& lock,
                       std::vector<OSMConnectionEdge>& connection_edges) {
   PointLL stop_ll = {stop.lon(), stop.lat() };
@@ -546,7 +550,7 @@ void build(const std::string& transit_dir,
 
       // Form connections to the stop
       // TODO - deal with hierarchy (only connect egress locations)
-      AddOSMConnection(stop, local_tile, hierarchy_local_level, reader_local_level, lock, connection_edges);
+      AddOSMConnection(stop, local_tile, hierarchy_local_level, lock, connection_edges);
 
       /** TODO - parent/child relationships
       if (stop.type == 0 && stop.parent.Is_Valid()) {
@@ -563,8 +567,8 @@ void build(const std::string& transit_dir,
 
     // Connect the transit graph to the route graph
     ConnectToGraph(tilebuilder_local, hierarchy_local_level, tilebuilder_transit,
-                   hierarchy_transit_level, transit_dir, local_tile,
-                   tiles, connection_edges);
+                   hierarchy_transit_level, transit_dir, local_tile, reader_transit_level,
+                   lock, tiles, connection_edges);
 
     // Write the new file
     lock.lock();

--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -1377,8 +1377,8 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
       directededge.set_speed(5);
       directededge.set_classification(RoadClass::kServiceOther);
       directededge.set_localedgeidx(tilebuilder_transit.directededges().size() - node.edge_index());
-      directededge.set_forwardaccess(n_access);
-      directededge.set_reverseaccess(n_access);
+      directededge.set_forwardaccess((kPedestrianAccess | kWheelchairAccess | kBicycleAccess));
+      directededge.set_reverseaccess((kPedestrianAccess | kWheelchairAccess | kBicycleAccess));
       directededge.set_lineid(transitedge.lineid);
 
       LOG_DEBUG("Add transit directededge - lineId = " + std::to_string(transitedge.lineid) +


### PR DESCRIPTION
Now using the access from the transit tiles.  We set access at the node level via valhalla_build_transit and propagate it to the transit connections during the transitbuilder phase.  Finally, the access for transit stops is reset to (kPedestrianAccess | kWheelchairAccess | kBicycleAccess)