### PR TITLE
bin the other levels now that they arent all on the local

### DIFF
--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -252,7 +252,7 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode, DirectedEdge& edge,
 using tweeners_t = GraphTileBuilder::tweeners_t;
 void validate(const boost::property_tree::ptree& pt,
               std::deque<GraphId>& tilequeue, std::mutex& lock,
-              std::promise<std::tuple<std::vector<uint32_t>, std::vector<std::vector<float>>, tweeners_t>>& result) {
+              std::promise<std::tuple<std::vector<uint32_t>, std::vector<std::vector<float> >, tweeners_t> >& result) {
     // Our local copy of edges binned to tiles that they pass through (dont start or end in)
     tweeners_t tweeners;
     // Local Graphreader
@@ -421,8 +421,6 @@ void validate(const boost::property_tree::ptree& pt,
 
       // Write the bins to it
       if (tile->header()->graphid().level() == hierarchy.levels().rbegin()->first) {
-
-        // TODO: we could just also make tilebuilder::Update write the bins
         auto reloaded = GraphTile(hierarchy, tile_id);
         GraphTileBuilder::AddBins(hierarchy, &reloaded, bins);
       }
@@ -471,20 +469,16 @@ void validate(const boost::property_tree::ptree& pt,
       ++start;
       lock.unlock();
 
-      //ignore transit tiles.
-      if (tile_bin.first.level() <= hierarchy.levels().rbegin()->second.level) {
+      //if there is nothing there we need to make something
+      GraphTile tile(hierarchy, tile_bin.first);
 
-        //if there is nothing there we need to make something
-        GraphTile tile(hierarchy, tile_bin.first);
-
-        if(tile.size() == 0) {
-          GraphTileBuilder empty(hierarchy, tile_bin.first, false);
-          empty.StoreTileData();
-          tile = GraphTile(hierarchy, tile_bin.first);
-        }
-        //keep the extra binned edges
-        GraphTileBuilder::AddBins(hierarchy, &tile, tile_bin.second);
+      if(tile.size() == 0) {
+        GraphTileBuilder empty(hierarchy, tile_bin.first, false);
+        empty.StoreTileData();
+        tile = GraphTile(hierarchy, tile_bin.first);
       }
+      //keep the extra binned edges
+      GraphTileBuilder::AddBins(hierarchy, &tile, tile_bin.second);
     }
   }
 }

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -448,7 +448,7 @@ void RemoveUnusedLocalTiles(const TileHierarchy& tile_hierarchy,
       std::string file_location = tile_hierarchy.tile_dir() + "/" +
           GraphTile::FileSuffix(empty_tile.Tile_Base(), tile_hierarchy);
       remove(file_location.c_str());
-      LOG_INFO("Remove file: " + file_location);
+      LOG_DEBUG("Remove file: " + file_location);
     }
   }
 }


### PR DESCRIPTION
this was a simple addition. all i had to do was remove the bit about skipping the other levels. after that i had to change the bit about checking tile ids based on edge id back to ids based on shape points. from there there was only one more change which was to make all the non local tiles bins look like `tweeners` so that they'd get added to the local levels at a later point in the validator.