### PR TITLE
Make sure transfercount is set to 0 in the headerbuilder. 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -181,6 +181,7 @@ valhalla_build_statistics_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) @BOOST_LDFL
 # tests
 check_PROGRAMS = \
 	test/utrecht \
+	test/countryaccess \
 	test/edgeinfobuilder \
 	test/uniquenames \
 	test/idtable \
@@ -189,9 +190,9 @@ check_PROGRAMS = \
 	test/names \
 	test/refs \
 	test/signinfo
-#test_countryaccess_SOURCES = test/countryaccess.cc test/test.cc
-#test_countryaccess_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS) @BOOST_CPPFLAGS@
-#test_countryaccess_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) @BOOST_LDFLAGS@ libvalhalla_mjolnir.la
+test_countryaccess_SOURCES = test/countryaccess.cc test/test.cc
+test_countryaccess_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS) @BOOST_CPPFLAGS@
+test_countryaccess_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) @BOOST_LDFLAGS@ libvalhalla_mjolnir.la
 test_utrecht_SOURCES = test/utrecht.cc test/test.cc
 test_utrecht_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS) @BOOST_CPPFLAGS@
 test_utrecht_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) @BOOST_LDFLAGS@ libvalhalla_mjolnir.la

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -289,6 +289,7 @@ void GraphTileBuilder::StoreTileData() {
     header_builder_.set_stopcount(stop_builder_.size());
     header_builder_.set_routecount(route_builder_.size());
     header_builder_.set_schedulecount(schedule_builder_.size());
+    header_builder_.set_transfercount(0); // TODO add later
     header_builder_.set_signcount(signs_builder_.size());
     header_builder_.set_admincount(admins_builder_.size());
     header_builder_.set_complex_restriction_forward_offset(
@@ -300,6 +301,7 @@ void GraphTileBuilder::StoreTileData() {
             + (stop_builder_.size() * sizeof(TransitStop))
             + (route_builder_.size() * sizeof(TransitRoute))
             + (schedule_builder_.size() * sizeof(TransitSchedule))
+            // TODO - once transit transfers are added need to update here
             + (signs_builder_.size() * sizeof(Sign))
             + (admins_builder_.size() * sizeof(Admin)));
 


### PR DESCRIPTION
Add a placeholder for when we add transit transfer records.
Fixes countryaccess test.