### PR TITLE
Update argument processing

### DIFF
--- a/src/mjolnir/valhalla_build_tiles.cc
+++ b/src/mjolnir/valhalla_build_tiles.cc
@@ -59,27 +59,23 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  bool info_only = false;
+  // Print out help or version and return
   if (vm.count("help")) {
     std::cout << options << "\n";
-    info_only = true;
+    return EXIT_SUCCESS;
   }
   if (vm.count("version")) {
     std::cout << "valhalla_build_tiles " << VERSION << "\n";
-    info_only = true;
+    return EXIT_SUCCESS;
   }
 
   // Exit if no config file or no input pbf files
   if (!vm.count("config") || !boost::filesystem::is_regular_file(config_file_path)) {
-    if (!info_only) {
-      std::cerr << "Configuration file is required\n\n" << options << "\n\n";
-    }
+    std::cerr << "Configuration file is required\n\n" << options << "\n\n";
     return EXIT_FAILURE;
   }
   if (input_files.size() == 0) {
-    if (!info_only) {
-      std::cerr << "Input file is required\n\n" << options << "\n\n";
-    }
+    std::cerr << "Input file is required\n\n" << options << "\n\n";
     return EXIT_FAILURE;
   }
 

--- a/src/mjolnir/valhalla_build_tiles.cc
+++ b/src/mjolnir/valhalla_build_tiles.cc
@@ -28,73 +28,62 @@ using namespace valhalla::mjolnir;
 
 namespace bpo = boost::program_options;
 
-boost::filesystem::path config_file_path;
-std::vector<std::string> input_files;
-
-bool ParseArguments(int argc, char *argv[]) {
-
+int main(int argc, char** argv) {
+  // Program options
+  boost::filesystem::path config_file_path;
+  std::vector<std::string> input_files;
   bpo::options_description options(
-    "pbfgraphbuilder " VERSION "\n"
-    "\n"
-    " Usage: pbfgraphbuilder [options] <protocolbuffer_input_file>\n"
-    "\n"
-    "pbfgraphbuilder is a program that creates the route graph from a osm.pbf "
-    "extract or osm2pgsql import.  You should use the lua scripts provided for "
-    "either method.  The scripts are located in the ./import/osm2pgsql directory.  "
-    "Moreover, sample json cofigs are located in ./import/configs directory."
-    "\n"
-    "\n");
+    "valhalla_build_tiles " VERSION "\n\n"
+    "Usage: valhalla_build_tiles [options] <protocolbuffer_input_file>\n\n"
+    "valhalla_build_tiles is a program that creates the route graph from an osm.pbf "
+    "extract. Sample json configs are located in ../conf directory.\n\n");
 
   options.add_options()
       ("help,h", "Print this help message.")
       ("version,v", "Print the version of this software.")
       ("config,c",
-        boost::program_options::value<boost::filesystem::path>(&config_file_path)->required(),
+        boost::program_options::value<boost::filesystem::path>(&config_file_path),
         "Path to the json configuration file.")
       // positional arguments
       ("input_files", boost::program_options::value<std::vector<std::string> >(&input_files)->multitoken());
 
   bpo::positional_options_description pos_options;
   pos_options.add("input_files", 16);
-
   bpo::variables_map vm;
   try {
     bpo::store(bpo::command_line_parser(argc, argv).options(options).positional(pos_options).run(), vm);
     bpo::notify(vm);
 
   } catch (std::exception &e) {
-    std::cerr << "Unable to parse command line options because: " << e.what()
-      << "\n" << "This is a bug, please report it at " PACKAGE_BUGREPORT
-      << "\n";
-    return false;
+    std::cerr << "Unable to parse command line options because: " << e.what() << "\n";
+    return EXIT_FAILURE;
   }
 
+  bool info_only = false;
   if (vm.count("help")) {
     std::cout << options << "\n";
-    return true;
+    info_only = true;
   }
-
   if (vm.count("version")) {
-    std::cout << "pbfgraphbuilder " << VERSION << "\n";
-    return true;
+    std::cout << "valhalla_build_tiles " << VERSION << "\n";
+    info_only = true;
   }
 
-  if (vm.count("config")) {
-    if (boost::filesystem::is_regular_file(config_file_path))
-      return true;
-    else
+  // Exit if no config file or no input pbf files
+  if (!vm.count("config") || !boost::filesystem::is_regular_file(config_file_path)) {
+    if (!info_only) {
       std::cerr << "Configuration file is required\n\n" << options << "\n\n";
+    }
+    return EXIT_FAILURE;
+  }
+  if (input_files.size() == 0) {
+    if (!info_only) {
+      std::cerr << "Input file is required\n\n" << options << "\n\n";
+    }
+    return EXIT_FAILURE;
   }
 
-  return false;
-}
-
-int main(int argc, char** argv) {
-
-  if (!ParseArguments(argc, argv))
-    return EXIT_FAILURE;
-
-  //check what type of input we are getting
+  // Read the config file
   boost::property_tree::ptree pt;
   boost::property_tree::read_json(config_file_path.c_str(), pt);
 


### PR DESCRIPTION
Refer to app. as valhalla_build_tiles consistently. Update argument parsing to allow -h and/or -c by themselves. Update error message for missing config file and check if no input files are specified.

Fixes #599 and fixes #600 